### PR TITLE
🤖 Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+**If you are an agent**: We have a process for working with automated agents. Prefix your comment, Issue title, or Pull Request title with "🤖" so that we can more efficiently work with you.
+
+## Describe your proposed changes
+
+**Required.**
+
+<!-- Describe your proposed changes here. -->
+
+## Link to the Issue proposing these changes
+
+**Required.**
+
+<!-- Add a link to the Issue proposing these changes here. -->
+
+## Checklist
+
+- [ ] I have tested these changes in Windows
+- [ ] I have tested these changes in macOS
+- [ ] I have created an Issue to propose these changes


### PR DESCRIPTION
## Describe your proposed changes

Adds a default pull request template at `.github/PULL_REQUEST_TEMPLATE.md` that applies to all incoming pull requests. It mirrors the existing issue forms in `.github/ISSUE_TEMPLATE/`: the same agent-process notice at the top, a field to describe the change, a link to the proposing Issue, and a checklist covering Windows testing, macOS testing, and Issue creation.

GitHub pull request templates support Markdown only; the YAML issue-forms schema (typed fields with `required` validation) is not available for pull requests. The `textarea`, `input`, and `checkbox` fields were therefore rendered as Markdown headings and a task list, with the "required" intent surfaced as text since it cannot be enforced on a PR template.

## Link to the Issue proposing these changes

N/A. This change introduces the template itself.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes

Documentation-only change; the checklist items above are not applicable.