### PR TITLE
🤖 Sync package-lock license with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "what-cant-i-press",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",
         "lucide": "^1.24.0"


### PR DESCRIPTION
## Describe your proposed changes

**Required.**

Commit `47120d4` ("Prepare 1.0.0") changed the `package.json` `license` field to `PolyForm-Noncommercial-1.0.0` but left the `package-lock.json` root package entry at `MIT`. That left the lockfile out of sync with the manifest, so any `npm install` regenerates the field and produces a spurious diff.

This regenerates the lockfile with `npm install --package-lock-only`. Only the root `""` package `license` changes, from `MIT` to `PolyForm-Noncommercial-1.0.0`. Dependency license fields and all resolved dependency versions are unchanged (one line changed).

## Link to the Issue proposing these changes

**Required.**

N/A. Lockfile metadata sync with no associated Issue.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes

<!-- Metadata-only lockfile change; no runtime behavior to test on either platform. -->