### PR TITLE
🤖 Guarantee menu-bar app reachability on first launch (v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ For example, <kbd>h</kbd> is often used to toggle open help dialogs. <kbd>h</
 
 What Can’t I Press lives in your menu bar (macOS) or system tray (Windows)—not the Dock or taskbar. Click its icon to open the popover. It also opens automatically the first time you launch it so you can find it.
 
-If you can’t see the icon (a crowded menu bar or a MacBook notch can hide it), press <kbd>⌘</kbd><kbd>Shift</kbd><kbd>P</kbd> on macOS or <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>P</kbd> on Windows to toggle the popover from anywhere. The exact shortcut is shown at the top of the icon’s menu and in the About window; it falls back to another combination if that one is already claimed.
-
 ### Scan to discover shortcuts
 
 - Detect shortcuts in the app you had open prior to opening What Can’t I Press, or

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ For example, <kbd>h</kbd> is often used to toggle open help dialogs. <kbd>h</
 
 ## How to use
 
+### Opening the app
+
+What Can’t I Press lives in your menu bar (macOS) or system tray (Windows)—not the Dock or taskbar. Click its icon to open the popover. It also opens automatically the first time you launch it so you can find it.
+
+If you can’t see the icon (a crowded menu bar or a MacBook notch can hide it), press <kbd>⌘</kbd><kbd>Shift</kbd><kbd>P</kbd> on macOS or <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>P</kbd> on Windows to toggle the popover from anywhere. The exact shortcut is shown at the top of the icon’s menu and in the About window; it falls back to another combination if that one is already claimed.
+
 ### Scan to discover shortcuts
 
 - Detect shortcuts in the app you had open prior to opening What Can’t I Press, or

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/main/core/logger.ts
+++ b/src/main/core/logger.ts
@@ -1,0 +1,48 @@
+import { app } from 'electron'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+let cachedPath: string | null = null
+
+/** Resolves (and creates) the log directory once. Returns null if it can't. */
+function ensurePath(): string | null {
+  if (cachedPath) return cachedPath
+  try {
+    const dir = join(app.getPath('userData'), 'logs')
+    mkdirSync(dir, { recursive: true })
+    cachedPath = join(dir, 'main.log')
+    return cachedPath
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Appends a timestamped line to `userData/logs/main.log` and mirrors it to
+ * stderr. Best-effort: any failure is swallowed so logging never affects
+ * startup. The file records the tray/status-item outcome on machines where the
+ * app is launched from Finder with no attached terminal — the record needed to
+ * pin down why a status item may not appear.
+ */
+export function log(message: string): void {
+  const line = `${new Date().toISOString()} ${message}`
+  // Mirror to stderr so a `.../Contents/MacOS/<binary>` terminal run shows it too.
+  console.error(`[wcip] ${line}`)
+  const path = ensurePath()
+  if (!path) return
+  try {
+    appendFileSync(path, line + '\n')
+  } catch {
+    // Best-effort logging only.
+  }
+}
+
+/** Serializes an unknown thrown value to a loggable string with a stack if present. */
+export function describeError(err: unknown): string {
+  return err instanceof Error ? (err.stack ?? err.message) : String(err)
+}
+
+/** Absolute path to the log file, for surfacing to the user. */
+export function logFilePath(): string {
+  return ensurePath() ?? join(app.getPath('userData'), 'logs', 'main.log')
+}

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -1,0 +1,41 @@
+import { app } from 'electron'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+interface Settings {
+  hasLaunched?: boolean
+}
+
+function settingsPath(): string {
+  return join(app.getPath('userData'), 'settings.json')
+}
+
+function read(): Settings {
+  try {
+    return JSON.parse(readFileSync(settingsPath(), 'utf8')) as Settings
+  } catch {
+    // Missing or unreadable file is treated as a fresh install.
+    return {}
+  }
+}
+
+function write(settings: Settings): void {
+  try {
+    writeFileSync(settingsPath(), JSON.stringify(settings, null, 2))
+  } catch {
+    // Best-effort: a failed write just means the first-run UI shows again later.
+  }
+}
+
+/**
+ * Returns true exactly once — on the first launch (or after the settings file is
+ * cleared) — and records the launch so later runs return false. Used to reveal
+ * the popover once, so a first launch of this menu-bar-only app always produces
+ * visible UI even if the status item never appears.
+ */
+export function isFirstLaunch(): boolean {
+  const settings = read()
+  if (settings.hasLaunched) return false
+  write({ ...settings, hasLaunched: true })
+  return true
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,15 +1,38 @@
-import { app, Menu, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { app, globalShortcut, Menu, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { IPC, type MenuCommand } from '@shared/ipc'
 import { createTrayIcon } from './icon'
-import { createAboutWindow, createPopoverWindow, positionPopover, popoverState } from './window'
+import {
+  createAboutWindow,
+  createPopoverWindow,
+  positionPopover,
+  formatAccelerator,
+  popoverState
+} from './window'
 import { registerIpc } from './ipc'
 import { getProvider } from './providers'
 import { foreground } from './core/foreground'
+import { log, describeError, logFilePath } from './core/logger'
+import { isFirstLaunch } from './core/settings'
 import { initAutoUpdater, checkForUpdatesManually } from './updater'
 
 let tray: Tray | null = null
 let popover: BrowserWindow | null = null
 let aboutWindow: BrowserWindow | null = null
+
+/**
+ * Candidate accelerators for the global toggle shortcut, tried in order. The
+ * first not already claimed by another app is registered, so the popover can be
+ * summoned even when the menu-bar status item never appears. The chosen
+ * accelerator is surfaced in the tray menu and the About window.
+ */
+const SHORTCUT_CANDIDATES = [
+  'CommandOrControl+Shift+P',
+  'CommandOrControl+Alt+P',
+  'CommandOrControl+Shift+K',
+  'CommandOrControl+Alt+K'
+]
+
+let activeAccelerator: string | null = null
 
 /**
  * Captures the app that is frontmost right now — before our popover shows and
@@ -28,20 +51,38 @@ async function captureForegroundApp(): Promise<void> {
 
 /** Positions and reveals the popover. Does not capture the frontmost app. */
 function showPopover(): void {
-  if (!popover || !tray) return
+  if (!popover) return
   positionPopover(popover, tray)
   popover.show()
   popover.focus()
 }
 
 async function togglePopover(): Promise<void> {
-  if (!popover || !tray) return
+  if (!popover) return
   if (popover.isVisible()) {
     popover.hide()
     return
   }
   await captureForegroundApp()
   showPopover()
+}
+
+/**
+ * Registers the first available global toggle shortcut, storing it in
+ * `activeAccelerator`. If every candidate is already claimed the failure is
+ * logged but non-fatal — the tray and first-run popover remain.
+ */
+function registerGlobalToggle(): void {
+  for (const accelerator of SHORTCUT_CANDIDATES) {
+    if (globalShortcut.isRegistered(accelerator)) continue
+    const ok = globalShortcut.register(accelerator, () => void togglePopover())
+    if (ok) {
+      activeAccelerator = accelerator
+      log(`Global toggle shortcut registered: ${accelerator}`)
+      return
+    }
+  }
+  log('Global toggle shortcut: no candidate could be registered')
 }
 
 /**
@@ -65,7 +106,7 @@ function showAbout(): void {
     aboutWindow.focus()
     return
   }
-  aboutWindow = createAboutWindow()
+  aboutWindow = createAboutWindow(activeAccelerator)
   aboutWindow.on('closed', () => {
     aboutWindow = null
   })
@@ -83,7 +124,10 @@ function showAbout(): void {
 function showTrayMenu(): void {
   if (!tray) return
   void captureForegroundApp()
+  const openLabel = activeAccelerator ? `Open  ${formatAccelerator(activeAccelerator)}` : 'Open'
   const template: MenuItemConstructorOptions[] = [
+    { label: openLabel, click: () => showPopover() },
+    { type: 'separator' },
     { label: 'Scan last focused app', click: () => runMenuCommand('scan-frontmost') },
     { label: 'Scan all open apps', click: () => runMenuCommand('scan-all') },
     { type: 'separator' },
@@ -98,31 +142,66 @@ function showTrayMenu(): void {
 }
 
 app.whenReady().then(() => {
+  log(`App ready (log file: ${logFilePath()})`)
+
   // Menu-bar-only app: no Dock icon on macOS.
   if (process.platform === 'darwin') app.dock?.hide()
 
   registerIpc(() => popover)
 
   popover = createPopoverWindow()
+  log('Popover window created')
 
-  tray = new Tray(createTrayIcon())
-  tray.setToolTip("What Can't I Press")
-  tray.on('click', (event) => {
-    // Control-click on macOS is a secondary click: show the context menu, the
-    // same as a right-click, instead of toggling the popover.
-    if (process.platform === 'darwin' && event.ctrlKey) {
-      showTrayMenu()
-      return
-    }
-    void togglePopover()
-  })
-  tray.on('right-click', showTrayMenu)
+  // The status item is the primary entry point; guard its creation so a failure
+  // can't leave the app running but invisible. Bounds are logged so a status
+  // item that was created yet not shown (zero width / menu-bar overflow) can be
+  // told apart from one that threw.
+  try {
+    tray = new Tray(createTrayIcon())
+    tray.setToolTip("What Can't I Press")
+    tray.on('click', (event) => {
+      // Control-click on macOS is a secondary click: show the context menu, the
+      // same as a right-click, instead of toggling the popover.
+      if (process.platform === 'darwin' && event.ctrlKey) {
+        showTrayMenu()
+        return
+      }
+      void togglePopover()
+    })
+    tray.on('right-click', showTrayMenu)
+    const b = tray.getBounds()
+    log(`Tray created (bounds x=${b.x} y=${b.y} w=${b.width} h=${b.height})`)
+  } catch (err) {
+    tray = null
+    log(`Tray creation failed: ${describeError(err)}`)
+  }
+
+  // Always give a keyboard path to the popover so a missing status item is not a
+  // dead end.
+  registerGlobalToggle()
+
+  // First launch of a menu-bar-only app is otherwise silent and invisible:
+  // reveal the popover once so the user gets confirmation the app is running and
+  // learns where it lives.
+  if (isFirstLaunch()) {
+    log('First launch: revealing popover')
+    showPopover()
+  }
 
   // Background update checks (Windows packaged builds only; see updater.ts).
   initAutoUpdater()
+}).catch((err) => {
+  // A throw here previously left the app running with no tray, no window, and no
+  // trace; record it instead.
+  log(`Startup failed: ${describeError(err)}`)
 })
 
 // Keep running as a background menu-bar app even with no visible windows.
 app.on('window-all-closed', () => {
   // Intentionally empty: do not quit when the popover is hidden/closed.
+})
+
+// Release the global shortcut(s) on exit.
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll()
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,13 +1,7 @@
-import { app, globalShortcut, Menu, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { app, Menu, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { IPC, type MenuCommand } from '@shared/ipc'
 import { createTrayIcon } from './icon'
-import {
-  createAboutWindow,
-  createPopoverWindow,
-  positionPopover,
-  formatAccelerator,
-  popoverState
-} from './window'
+import { createAboutWindow, createPopoverWindow, positionPopover, popoverState } from './window'
 import { registerIpc } from './ipc'
 import { getProvider } from './providers'
 import { foreground } from './core/foreground'
@@ -18,21 +12,6 @@ import { initAutoUpdater, checkForUpdatesManually } from './updater'
 let tray: Tray | null = null
 let popover: BrowserWindow | null = null
 let aboutWindow: BrowserWindow | null = null
-
-/**
- * Candidate accelerators for the global toggle shortcut, tried in order. The
- * first not already claimed by another app is registered, so the popover can be
- * summoned even when the menu-bar status item never appears. The chosen
- * accelerator is surfaced in the tray menu and the About window.
- */
-const SHORTCUT_CANDIDATES = [
-  'CommandOrControl+Shift+P',
-  'CommandOrControl+Alt+P',
-  'CommandOrControl+Shift+K',
-  'CommandOrControl+Alt+K'
-]
-
-let activeAccelerator: string | null = null
 
 /**
  * Captures the app that is frontmost right now — before our popover shows and
@@ -68,24 +47,6 @@ async function togglePopover(): Promise<void> {
 }
 
 /**
- * Registers the first available global toggle shortcut, storing it in
- * `activeAccelerator`. If every candidate is already claimed the failure is
- * logged but non-fatal — the tray and first-run popover remain.
- */
-function registerGlobalToggle(): void {
-  for (const accelerator of SHORTCUT_CANDIDATES) {
-    if (globalShortcut.isRegistered(accelerator)) continue
-    const ok = globalShortcut.register(accelerator, () => void togglePopover())
-    if (ok) {
-      activeAccelerator = accelerator
-      log(`Global toggle shortcut registered: ${accelerator}`)
-      return
-    }
-  }
-  log('Global toggle shortcut: no candidate could be registered')
-}
-
-/**
  * Forwards a tray-menu action to the renderer, which owns the scan/export/pin
  * logic and state. Reveals the popover first so results, progress, and dialogs
  * are visible.
@@ -106,7 +67,7 @@ function showAbout(): void {
     aboutWindow.focus()
     return
   }
-  aboutWindow = createAboutWindow(activeAccelerator)
+  aboutWindow = createAboutWindow()
   aboutWindow.on('closed', () => {
     aboutWindow = null
   })
@@ -124,10 +85,7 @@ function showAbout(): void {
 function showTrayMenu(): void {
   if (!tray) return
   void captureForegroundApp()
-  const openLabel = activeAccelerator ? `Open  ${formatAccelerator(activeAccelerator)}` : 'Open'
   const template: MenuItemConstructorOptions[] = [
-    { label: openLabel, click: () => showPopover() },
-    { type: 'separator' },
     { label: 'Scan last focused app', click: () => runMenuCommand('scan-frontmost') },
     { label: 'Scan all open apps', click: () => runMenuCommand('scan-all') },
     { type: 'separator' },
@@ -176,10 +134,6 @@ app.whenReady().then(() => {
     log(`Tray creation failed: ${describeError(err)}`)
   }
 
-  // Always give a keyboard path to the popover so a missing status item is not a
-  // dead end.
-  registerGlobalToggle()
-
   // First launch of a menu-bar-only app is otherwise silent and invisible:
   // reveal the popover once so the user gets confirmation the app is running and
   // learns where it lives.
@@ -199,9 +153,4 @@ app.whenReady().then(() => {
 // Keep running as a background menu-bar app even with no visible windows.
 app.on('window-all-closed', () => {
   // Intentionally empty: do not quit when the popover is hidden/closed.
-})
-
-// Release the global shortcut(s) on exit.
-app.on('will-quit', () => {
-  globalShortcut.unregisterAll()
 })

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -75,11 +75,8 @@ export function createPopoverWindow(): BrowserWindow {
 const ABOUT_URL = 'https://github.com/ericwbailey/what-cant-i-press'
 
 /** Builds the About window's self-contained HTML document. */
-function aboutHtml(version: string, accelerator: string | null): string {
+function aboutHtml(version: string): string {
   const currentYear = new Date().getFullYear()
-  const toggleLine = accelerator
-    ? `<p class="toggle">Toggle: ${formatAccelerator(accelerator)}</p>`
-    : ''
   return `<!doctype html>
 <html>
 <head>
@@ -108,7 +105,6 @@ function aboutHtml(version: string, accelerator: string | null): string {
   h1 { margin: 0 0 6px; font-size: 15px; font-weight: 700; }
   p { margin: 0; }
   .app-icon { width: 80px; height: 80px; margin: 0 0 12px; -webkit-user-drag: none; }
-  .toggle { margin-top: 4px; opacity: 0.7; }
   .author { margin-top: 16px; }
   /* Plain-text link: inherits the body color, underlined. */
   a.website { color: inherit; text-decoration: underline; cursor: pointer; }
@@ -118,7 +114,6 @@ function aboutHtml(version: string, accelerator: string | null): string {
   <img class="app-icon" src="${ABOUT_ICON_DATA_URL}" alt="" aria-hidden="true" width="80" height="80" />
   <h1>What Can't I Press?</h1>
   <p>Version ${version}</p>
-  ${toggleLine}
   <p><a class="website" href="${ABOUT_URL}">Source</a></p>
   <p class="author">Eric Bailey © ${currentYear}</p>
 </body>
@@ -129,9 +124,8 @@ function aboutHtml(version: string, accelerator: string | null): string {
  * Creates the small About window. Its "Source" link is styled as underlined
  * plain text and opens in the user's default browser; the window itself never
  * navigates. Self-contained HTML is loaded from a data URL (no renderer entry).
- * `accelerator`, when set, is shown so users can find the global toggle shortcut.
  */
-export function createAboutWindow(accelerator: string | null = null): BrowserWindow {
+export function createAboutWindow(): BrowserWindow {
   const win = new BrowserWindow({
     width: ABOUT_WIDTH,
     height: ABOUT_HEIGHT,
@@ -163,7 +157,7 @@ export function createAboutWindow(accelerator: string | null = null): BrowserWin
 
   win.once('ready-to-show', () => win.show())
   void win.loadURL(
-    'data:text/html;charset=utf-8,' + encodeURIComponent(aboutHtml(app.getVersion(), accelerator))
+    'data:text/html;charset=utf-8,' + encodeURIComponent(aboutHtml(app.getVersion()))
   )
 
   return win
@@ -208,8 +202,8 @@ export function setPinned(win: BrowserWindow, pinned: boolean): boolean {
  * `tray` may be null, or report zero-width bounds when the status item failed to
  * appear or overflowed off the menu bar. In that case the popover is still
  * placed somewhere visible (top-center of the primary display on macOS, the
- * primary work-area corner elsewhere) so it stays reachable via the global
- * shortcut even with no usable status item.
+ * primary work-area corner elsewhere) so the first-run reveal is visible even
+ * with no usable status item.
  */
 export function positionPopover(win: BrowserWindow, tray: Tray | null): void {
   const winBounds = win.getBounds()
@@ -238,22 +232,6 @@ export function positionPopover(win: BrowserWindow, tray: Tray | null): void {
   const x = Math.round(workArea.x + workArea.width - winBounds.width - SCREEN_MARGIN)
   const y = Math.round(workArea.y + workArea.height - winBounds.height - SCREEN_MARGIN)
   win.setPosition(x, y, false)
-}
-
-/**
- * Renders an Electron accelerator for display: menu-style symbols on macOS
- * (⌘⇧P), a readable plus-form elsewhere (Ctrl+Shift+P).
- */
-export function formatAccelerator(accelerator: string): string {
-  if (process.platform !== 'darwin') return accelerator.replace('CommandOrControl', 'Ctrl')
-  return accelerator
-    .replace('CommandOrControl', '⌘')
-    .replace('Command', '⌘')
-    .replace('Control', '⌃')
-    .replace('Alt', '⌥')
-    .replace('Option', '⌥')
-    .replace('Shift', '⇧')
-    .replace(/\+/g, '')
 }
 
 function clampX(x: number, width: number): number {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -75,8 +75,11 @@ export function createPopoverWindow(): BrowserWindow {
 const ABOUT_URL = 'https://github.com/ericwbailey/what-cant-i-press'
 
 /** Builds the About window's self-contained HTML document. */
-function aboutHtml(version: string): string {
+function aboutHtml(version: string, accelerator: string | null): string {
   const currentYear = new Date().getFullYear()
+  const toggleLine = accelerator
+    ? `<p class="toggle">Toggle: ${formatAccelerator(accelerator)}</p>`
+    : ''
   return `<!doctype html>
 <html>
 <head>
@@ -105,6 +108,7 @@ function aboutHtml(version: string): string {
   h1 { margin: 0 0 6px; font-size: 15px; font-weight: 700; }
   p { margin: 0; }
   .app-icon { width: 80px; height: 80px; margin: 0 0 12px; -webkit-user-drag: none; }
+  .toggle { margin-top: 4px; opacity: 0.7; }
   .author { margin-top: 16px; }
   /* Plain-text link: inherits the body color, underlined. */
   a.website { color: inherit; text-decoration: underline; cursor: pointer; }
@@ -114,6 +118,7 @@ function aboutHtml(version: string): string {
   <img class="app-icon" src="${ABOUT_ICON_DATA_URL}" alt="" aria-hidden="true" width="80" height="80" />
   <h1>What Can't I Press?</h1>
   <p>Version ${version}</p>
+  ${toggleLine}
   <p><a class="website" href="${ABOUT_URL}">Source</a></p>
   <p class="author">Eric Bailey © ${currentYear}</p>
 </body>
@@ -124,8 +129,9 @@ function aboutHtml(version: string): string {
  * Creates the small About window. Its "Source" link is styled as underlined
  * plain text and opens in the user's default browser; the window itself never
  * navigates. Self-contained HTML is loaded from a data URL (no renderer entry).
+ * `accelerator`, when set, is shown so users can find the global toggle shortcut.
  */
-export function createAboutWindow(): BrowserWindow {
+export function createAboutWindow(accelerator: string | null = null): BrowserWindow {
   const win = new BrowserWindow({
     width: ABOUT_WIDTH,
     height: ABOUT_HEIGHT,
@@ -156,7 +162,9 @@ export function createAboutWindow(): BrowserWindow {
   })
 
   win.once('ready-to-show', () => win.show())
-  void win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(aboutHtml(app.getVersion())))
+  void win.loadURL(
+    'data:text/html;charset=utf-8,' + encodeURIComponent(aboutHtml(app.getVersion(), accelerator))
+  )
 
   return win
 }
@@ -196,24 +204,56 @@ export function setPinned(win: BrowserWindow, pinned: boolean): boolean {
  * Positions the popover relative to the tray icon. On macOS the menu bar is at
  * the top, so the popover drops down from the icon; on Windows the tray sits in
  * the bottom-right, so it rises from the work-area corner.
+ *
+ * `tray` may be null, or report zero-width bounds when the status item failed to
+ * appear or overflowed off the menu bar. In that case the popover is still
+ * placed somewhere visible (top-center of the primary display on macOS, the
+ * primary work-area corner elsewhere) so it stays reachable via the global
+ * shortcut even with no usable status item.
  */
-export function positionPopover(win: BrowserWindow, tray: Tray): void {
-  const trayBounds = tray.getBounds()
+export function positionPopover(win: BrowserWindow, tray: Tray | null): void {
   const winBounds = win.getBounds()
+  const trayBounds = tray?.getBounds()
+  const hasTrayAnchor = !!trayBounds && trayBounds.width > 0
 
   if (process.platform === 'darwin') {
-    const x = Math.round(trayBounds.x + trayBounds.width / 2 - winBounds.width / 2)
-    const y = Math.round(trayBounds.y + trayBounds.height + TRAY_GAP)
-    win.setPosition(clampX(x, winBounds.width), y, false)
+    if (hasTrayAnchor) {
+      const x = Math.round(trayBounds.x + trayBounds.width / 2 - winBounds.width / 2)
+      const y = Math.round(trayBounds.y + trayBounds.height + TRAY_GAP)
+      win.setPosition(clampX(x, winBounds.width), y, false)
+      return
+    }
+    // No usable status item: drop from the top-center of the primary display,
+    // just below the menu bar (workArea.y already excludes it).
+    const primary = screen.getPrimaryDisplay().workArea
+    const x = Math.round(primary.x + primary.width / 2 - winBounds.width / 2)
+    win.setPosition(clampX(x, winBounds.width), primary.y + SCREEN_MARGIN, false)
     return
   }
 
-  // Windows / Linux: anchor to the display containing the tray.
-  const display = screen.getDisplayMatching(trayBounds)
+  // Windows / Linux: anchor to the display containing the tray, or the primary
+  // display when the tray is unavailable.
+  const display = hasTrayAnchor ? screen.getDisplayMatching(trayBounds) : screen.getPrimaryDisplay()
   const workArea = display.workArea
   const x = Math.round(workArea.x + workArea.width - winBounds.width - SCREEN_MARGIN)
   const y = Math.round(workArea.y + workArea.height - winBounds.height - SCREEN_MARGIN)
   win.setPosition(x, y, false)
+}
+
+/**
+ * Renders an Electron accelerator for display: menu-style symbols on macOS
+ * (⌘⇧P), a readable plus-form elsewhere (Ctrl+Shift+P).
+ */
+export function formatAccelerator(accelerator: string): string {
+  if (process.platform !== 'darwin') return accelerator.replace('CommandOrControl', 'Ctrl')
+  return accelerator
+    .replace('CommandOrControl', '⌘')
+    .replace('Command', '⌘')
+    .replace('Control', '⌃')
+    .replace('Alt', '⌥')
+    .replace('Option', '⌥')
+    .replace('Shift', '⇧')
+    .replace(/\+/g, '')
 }
 
 function clampX(x: number, width: number): number {


### PR DESCRIPTION
## Describe your proposed changes

**Required.**

What Can't I Press is a menu-bar-only app (no Dock or taskbar entry). On first launch it created its tray status item but never opened the popover, so a user whose menu-bar icon was hidden (a crowded menu bar or a MacBook notch) or whose tray creation silently failed had no way to reach the app and no diagnostic trail. It was reported as "the app won't launch / shows no window," when in fact the process was running the whole time.

This change keeps the pure menu-bar design but makes the app reachable and debuggable:

- **First-run reveal.** On the first launch only, the popover opens once so the user gets confirmation the app is running and learns where it lives. The "has launched before" flag is persisted in a small `settings.json` under userData (`src/main/core/settings.ts`).
- **Startup logging.** A lightweight file logger writes timestamped lines to `userData/logs/main.log` and mirrors to stderr (`src/main/core/logger.ts`). Tray creation is wrapped in try/catch with bounds logging, and `whenReady()` gains a `.catch`, so a startup throw leaves a trace instead of a silent dead process.
- **Tray-less positioning fallback.** `positionPopover` now accepts a null or zero-width tray and falls back to a visible location (top-center below the menu bar on macOS, the primary work-area corner elsewhere), so the first-run reveal is visible even if the status item never appears.
- **Version bump** 1.0.0 -> 1.0.1.

Note on history: the first commit added an interim global toggle shortcut (Command+Shift+P); the second commit removed it at the author's request. The net diff adds no global shortcut.

Out of scope: unsigned builds still trip Gatekeeper ("could not verify... free of malware"); that is a signing/notarization concern, separate from this reachability fix.

Testing: `npm run typecheck` and `npm run build` pass. The built app was launched on macOS in an isolated user-data dir; the log showed `App ready` -> `Popover window created` -> `Tray created` -> `First launch: revealing popover`, with no startup failure.

## Link to the Issue proposing these changes

**Required.**

N/A - no tracking issue.

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes