### PR TITLE
🤖 Add macOS Permissions window and restyle accessibility banner; bump to 1.1.0

### DIFF
--- a/native/macos/ShortcutHelper.swift
+++ b/native/macos/ShortcutHelper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AppKit
 import ApplicationServices
+import CoreServices
 
 // Emits a JSON value to stdout and exits.
 func emit(_ object: Any) -> Never {
@@ -41,6 +42,24 @@ func activate(_ pid: pid_t) -> Never {
 
 func axTrusted() -> Never {
     emit(["trusted": AXIsProcessTrusted()])
+}
+
+// Reports whether the app already holds Automation (Apple events) permission,
+// probed against System Events without prompting. macOS has no global Automation
+// grant, so System Events stands in as the representative target. Only an explicit
+// noErr counts as granted; a not-running target (procNotFound) reads as not granted.
+func automationTrusted() -> Never {
+    var target = AEAddressDesc()
+    let bundleId = Data("com.apple.systemevents".utf8)
+    let created = bundleId.withUnsafeBytes { raw in
+        AECreateDesc(typeApplicationBundleID, raw.baseAddress, bundleId.count, &target)
+    }
+    if created != noErr {
+        emit(["trusted": false])
+    }
+    let status = AEDeterminePermissionToAutomateTarget(&target, typeWildCard, typeWildCard, false)
+    AEDisposeDesc(&target)
+    emit(["trusted": status == noErr])
 }
 
 func copyAttr(_ element: AXUIElement, _ attribute: String) -> CFTypeRef? {
@@ -104,6 +123,8 @@ case "frontmost":
     frontmost()
 case "axtrust":
     axTrusted()
+case "autotrust":
+    automationTrusted()
 case "activate":
     guard args.count >= 3, let pid = Int32(args[2]) else { emit(["error": "missing pid"]) }
     activate(pid)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,9 +1,17 @@
-import { app, Menu, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { app, Menu, Tray, systemPreferences, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { IPC, type MenuCommand } from '@shared/ipc'
 import { createTrayIcon } from './icon'
-import { createAboutWindow, createPopoverWindow, positionPopover, popoverState } from './window'
+import {
+  createAboutWindow,
+  createPermissionsWindow,
+  createPopoverWindow,
+  positionPopover,
+  popoverState,
+  type PermissionSnapshot
+} from './window'
 import { registerIpc } from './ipc'
 import { getProvider } from './providers'
+import { automationTrusted } from './providers/macos'
 import { foreground } from './core/foreground'
 import { log, describeError, logFilePath } from './core/logger'
 import { initAutoUpdater, checkForUpdatesManually } from './updater'
@@ -11,6 +19,7 @@ import { initAutoUpdater, checkForUpdatesManually } from './updater'
 let tray: Tray | null = null
 let popover: BrowserWindow | null = null
 let aboutWindow: BrowserWindow | null = null
+let permissionsWindow: BrowserWindow | null = null
 
 /**
  * Captures the app that is frontmost right now — before our popover shows and
@@ -82,6 +91,31 @@ function showAbout(): void {
   })
 }
 
+/** Reads the current grant state of the macOS permissions the scan depends on. */
+async function permissionSnapshot(): Promise<PermissionSnapshot> {
+  return {
+    accessibility: systemPreferences.isTrustedAccessibilityClient(false),
+    automation: await automationTrusted()
+  }
+}
+
+/**
+ * Opens the macOS-only Permissions window, or focuses it if already open. The
+ * window lists the Accessibility and Automation permissions, each with a control
+ * that deep-links into System Settings and a status light reflecting whether the
+ * permission is granted. A single instance is reused.
+ */
+function showPermissions(): void {
+  if (permissionsWindow && !permissionsWindow.isDestroyed()) {
+    permissionsWindow.focus()
+    return
+  }
+  permissionsWindow = createPermissionsWindow(permissionSnapshot)
+  permissionsWindow.on('closed', () => {
+    permissionsWindow = null
+  })
+}
+
 /**
  * Builds and shows the tray context menu. Must run synchronously: on macOS the
  * status-item right-click is serviced inside a native mouse-tracking loop, and
@@ -102,6 +136,9 @@ function showTrayMenu(): void {
     { label: popoverState.pinned ? 'Unpin' : 'Pin', click: () => runMenuCommand('toggle-pin') },
     { type: 'separator' },
     { label: 'Check for updates', click: () => checkForUpdatesManually() },
+    ...(process.platform === 'darwin'
+      ? [{ label: 'Permissions', click: () => showPermissions() }]
+      : []),
     { label: 'About', click: () => showAbout() },
     { label: 'Quit', click: () => app.quit() }
   ]

--- a/src/main/providers/macos/index.ts
+++ b/src/main/providers/macos/index.ts
@@ -102,3 +102,14 @@ export class MacProvider implements PlatformProvider {
     }
   }
 }
+
+/**
+ * Whether the app currently holds Automation (Apple events) permission, probed
+ * against System Events without prompting. macOS has no single global Automation
+ * grant, so System Events stands in as the representative target. Returns false
+ * on any non-granted or unknown state (including the helper being unavailable).
+ */
+export async function automationTrusted(): Promise<boolean> {
+  const result = await runHelper<{ trusted: boolean }>(['autotrust'])
+  return result?.trusted ?? false
+}

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -6,6 +6,8 @@ const POPOVER_WIDTH = 552
 const POPOVER_HEIGHT = 682
 const ABOUT_WIDTH = 340
 const ABOUT_HEIGHT = 332
+const PERMISSIONS_WIDTH = 635
+const PERMISSIONS_HEIGHT = 180
 // Opaque light window background used off-macOS and by the About window; matches
 // the light --bg token so there is no flash before the renderer paints.
 const WINDOW_BG_LIGHT = '#f5f5f7'
@@ -162,6 +164,223 @@ export function createAboutWindow(): BrowserWindow {
   void win.loadURL(
     'data:text/html;charset=utf-8,' + encodeURIComponent(aboutHtml(app.getVersion()))
   )
+
+  return win
+}
+
+/** Current grant state of the two macOS permissions the scan depends on. */
+export interface PermissionSnapshot {
+  accessibility: boolean
+  automation: boolean
+}
+
+const PERMISSION_ROWS = [
+  {
+    id: 'accessibility',
+    label: 'Accessibility',
+    description: 'Reads menu-bar commands and custom keyboard shortcuts.',
+    settingsUrl: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
+  },
+  {
+    id: 'automation',
+    label: 'Automation',
+    description: 'Briefly activate each running app so its menus can be read.',
+    settingsUrl: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Automation'
+  }
+] as const
+
+/** Escapes text interpolated into the Permissions HTML. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/** Builds the Permissions window's self-contained HTML document. */
+function permissionsHtml(): string {
+  const rows = PERMISSION_ROWS.map(
+    (row) => `
+    <li class="perm-row">
+      <div class="perm-text">
+        <h2>${escapeHtml(row.label)}</h2>
+        <span>${escapeHtml(row.description)}</span>
+      </div>
+      <div class="perm-controls">
+        <a class="perm-settings" href="${escapeHtml(row.settingsUrl)}" aria-label="Settings: ${escapeHtml(row.label)}">Settings</a>
+        <span class="perm-status">
+          <span id="state-${row.id}" class="perm-state" aria-label="${escapeHtml(row.label)} disabled">Disabled</span>
+          <span id="light-${row.id}" class="perm-light" aria-hidden="true"></span>
+        </span>
+      </div>
+    </li>`
+  ).join('')
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'" />
+<style>
+  :root { color-scheme: light dark; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    background: Canvas;
+    color: CanvasText;
+    padding: 20px 22px;
+    box-sizing: border-box;
+    line-height: 1.4;
+    font-size: 13px;
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: default;
+  }
+  .visually-hidden {
+    position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+    border: 0; clip: rect(0 0 0 0); clip-path: inset(50%); overflow: hidden; white-space: nowrap;
+  }
+  ul.perm-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+  li.perm-row { display: flex; align-items: flex-end; gap: 14px; padding: 14px 0; }
+  li.perm-row:first-child { padding-top: 0; }
+  li.perm-row:last-child { padding-bottom: 0; }
+  li.perm-row + li.perm-row { border-top: 1px solid rgba(128, 128, 128, 0.22); }
+  .perm-text { flex: 1 1 auto; min-width: 0; }
+  .perm-text h2 { margin: 0 0 2px; font-size: 14px; font-weight: 600; }
+  .perm-text span { display: block; opacity: 0.65; font-size: 12px; }
+  .perm-controls { flex: 0 0 auto; display: flex; align-items: flex-end; gap: 16px; }
+  a.perm-settings {
+    display: inline-flex; align-items: center; justify-content: center; box-sizing: border-box;
+    height: 24px; padding: 0 12px; border: 1px solid rgba(128, 128, 128, 0.5); border-radius: 6px;
+    color: inherit; text-decoration: none; font-size: 12px; cursor: pointer; background: transparent;
+  }
+  a.perm-settings:hover { background: rgba(128, 128, 128, 0.14); }
+  .perm-status {
+    display: inline-flex; align-items: center; gap: 6px; box-sizing: border-box;
+    padding: 3px 6px 3px 9px; border: 1px solid rgba(128, 128, 128, 0.3); border-radius: 999px;
+  }
+  .perm-state {
+    font-size: 10px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+    opacity: 0.6; white-space: nowrap; min-width: 56px; text-align: left;
+  }
+  .perm-light { width: 12px; height: 12px; border-radius: 50%; flex: 0 0 auto; background: #6b6b6b; }
+  @media (prefers-color-scheme: dark) { .perm-light { background: #000; } }
+  .perm-light.granted { background: #30d158; }
+</style>
+</head>
+<body>
+  <h1 class="visually-hidden">Permissions</h1>
+  <ul class="perm-list">${rows}
+  </ul>
+</body>
+</html>`
+}
+
+/**
+ * Creates the small, macOS-only Permissions window. It mirrors the About window:
+ * self-contained HTML loaded from a data URL, no renderer entry, and link
+ * activation routed to the external handler — here the two "Settings" controls
+ * deep-link into the relevant System Settings panes. Each row's status light is
+ * driven from the main process via `executeJavaScript` (privileged, so it needs
+ * no inline script or preload) and re-read on load, on focus, and on a short
+ * interval, so a light turns green shortly after the user grants access and
+ * returns from System Settings.
+ */
+export function createPermissionsWindow(
+  getSnapshot: () => Promise<PermissionSnapshot>
+): BrowserWindow {
+  const win = new BrowserWindow({
+    width: PERMISSIONS_WIDTH,
+    height: PERMISSIONS_HEIGHT,
+    show: false,
+    resizable: false,
+    fullscreenable: false,
+    maximizable: false,
+    minimizable: false,
+    skipTaskbar: true,
+    title: 'Permissions',
+    backgroundColor: process.platform === 'darwin' ? undefined : WINDOW_BG_LIGHT,
+    webPreferences: { sandbox: true, contextIsolation: true }
+  })
+
+  win.setMenuBarVisibility(false)
+
+  // Route control activation to System Settings / the browser; deny in-window
+  // navigation. The Settings controls use the x-apple.systempreferences scheme.
+  const openExternal = (url: string): void => {
+    if (url.startsWith('https://') || url.startsWith('x-apple.systempreferences:')) {
+      void shell.openExternal(url)
+    }
+  }
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    openExternal(url)
+    return { action: 'deny' }
+  })
+  win.webContents.on('will-navigate', (event, url) => {
+    event.preventDefault()
+    openExternal(url)
+  })
+
+  // Pushes the latest grant state into the two status lights.
+  const refresh = async (): Promise<void> => {
+    if (win.isDestroyed()) return
+    let snapshot: PermissionSnapshot
+    try {
+      snapshot = await getSnapshot()
+    } catch {
+      return
+    }
+    if (win.isDestroyed()) return
+    const js = `(() => {
+      const set = (id, label, granted) => {
+        const light = document.getElementById('light-' + id);
+        if (light) light.classList.toggle('granted', granted);
+        const state = document.getElementById('state-' + id);
+        if (state) {
+          state.textContent = granted ? 'Enabled' : 'Disabled';
+          state.setAttribute('aria-label', label + (granted ? ' enabled' : ' disabled'));
+        }
+      };
+      set('accessibility', 'Accessibility', ${snapshot.accessibility});
+      set('automation', 'Automation', ${snapshot.automation});
+    })()`
+    try {
+      await win.webContents.executeJavaScript(js)
+    } catch {
+      // Window torn down mid-refresh.
+    }
+  }
+
+  // Shrinks the window to fit its content, then reveals it. The content height
+  // depends on how the descriptions wrap (window width, font size, localized
+  // strings), so it is measured after load rather than hard-coded — a fixed
+  // height previously left slack once the descriptions stopped wrapping.
+  const fitAndShow = async (): Promise<void> => {
+    if (win.isDestroyed()) return
+    try {
+      const height = await win.webContents.executeJavaScript(
+        `Math.ceil(document.querySelector('ul.perm-list').getBoundingClientRect().bottom` +
+          ` + parseFloat(getComputedStyle(document.body).paddingBottom))`
+      )
+      if (!win.isDestroyed() && typeof height === 'number' && height > 0) {
+        win.setContentSize(win.getContentBounds().width, height)
+      }
+    } catch {
+      // Fall back to the default height if measurement fails.
+    }
+    if (!win.isDestroyed()) win.show()
+  }
+
+  win.webContents.on('did-finish-load', () => {
+    void refresh()
+    void fitAndShow()
+  })
+  win.on('focus', () => void refresh())
+  const timer = setInterval(() => void refresh(), 2000)
+  win.on('closed', () => clearInterval(timer))
+
+  void win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(permissionsHtml()))
 
   return win
 }

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -874,21 +874,28 @@ function renderAppSection(
 function renderBanner(permission: PermissionStatus): void {
   if (permission.accessibility === 'denied') {
     bannerEl.innerHTML = `
-      <div class="banner banner-warn">
+      <section class="banner banner-warn" aria-labelledby="accessibility-access-needed">
         <div class="banner-body">
           <i data-lucide="triangle-alert" class="banner-icon" aria-hidden="true"></i>
           <div>
-            <strong>Accessibility access needed</strong>
+            <h2 id="accessibility-access-needed" class="banner-title">Accessibility access needed</h2>
             <div class="banner-detail">${escapeHtml(permission.details ?? 'Grant access to read app menu shortcuts.')}</div>
           </div>
         </div>
-        <button class="secondary" id="grant"><i data-lucide="shield-check" aria-hidden="true"></i>Grant access</button>
-      </div>
+        <button class="secondary" id="grant">Grant access</button>
+      </section>
     `
     renderIcons(bannerEl)
     const grant = document.getElementById('grant') as HTMLButtonElement
     grant.addEventListener('click', async () => {
-      await window.shortcutApi.requestPermission()
+      // requestPermission registers the app in the TCC Accessibility list and shows
+      // the native prompt on first run only; macOS never re-shows it once the app is
+      // listed, so also open the Accessibility pane directly so the click always has
+      // a visible effect and the user can toggle the grant.
+      await window.shortcutApi.requestPermission().catch(() => undefined)
+      await window.shortcutApi.openExternal(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
+      )
     })
     return
   }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -256,12 +256,19 @@ button.secondary {
   padding: 6px 12px;
   cursor: pointer;
   border: 1px solid var(--transparent);
+  transition: background-color 150ms ease, border-color 150ms ease;
 }
 
 button.secondary {
   background: var(--fill-subtle);
   color: var(--text);
   border-color: var(--border);
+}
+
+#scan-all:hover,
+#scan:hover {
+  background: color-mix(in srgb, var(--bg), var(--text) 10%);
+  border-color: color-mix(in srgb, var(--bg), var(--text) 30%);
 }
 
 button:disabled {
@@ -613,15 +620,15 @@ html[data-input='keyboard'] .row-button:focus {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin: 10px 14px 0;
+  margin: 10px 14px;
   padding: 10px 12px;
   border-radius: 8px;
   font-size: 12px;
+  color: var(--bg);
 }
 
 .banner-warn {
-  background: var(--warn-bg);
-  border: 1px solid var(--warn-border);
+  background: var(--text);
 }
 
 .banner-body {
@@ -635,7 +642,7 @@ html[data-input='keyboard'] .row-button:focus {
   height: 16px;
   flex: none;
   margin-top: 1px;
-  color: var(--warn-icon);
+  color: var(--bg);
 }
 
 #grant {
@@ -650,8 +657,24 @@ html[data-input='keyboard'] .row-button:focus {
   height: 14px;
 }
 
+.banner-warn #grant {
+  background: var(--bg);
+  color: var(--text);
+  border-color: transparent;
+}
+
+.banner-warn #grant:hover {
+  background: color-mix(in srgb, var(--bg), var(--text) 12%);
+}
+
+.banner-title {
+  margin: 0;
+  padding-top: 1px;
+  font-size: inherit;
+}
+
 .banner-detail {
-  color: var(--text-dim);
+  color: color-mix(in srgb, var(--bg), var(--text) 30%);
   margin-top: 3px;
   line-height: 1.4;
 }


### PR DESCRIPTION
**If you are an agent**: We have a process for working with automated agents. Prefix your comment, Issue title, or Pull Request title with "🤖" so that we can more efficiently work with you.

## Describe your proposed changes

**Required.**

Adds a macOS-only **Permissions** window and restyles the accessibility-access banner.

**Permissions window (macOS-only)**
- New tray **Permissions** item opens an About-style, self-contained data-URL window listing the two permissions the scan depends on: **Accessibility** and **Automation**.
- Each row has a **Settings** control that deep-links into the relevant System Settings pane (`Privacy_Accessibility` / `Privacy_Automation`), an Enabled/Disabled label, and a status light that turns green when the permission is granted. Status is re-read on load, on focus, and on a short interval, so a light updates shortly after the user returns from System Settings. The window fits its measured content height.
- Automation (Apple events) grant is probed against System Events without prompting via a new Swift `autotrust` subcommand + `automationTrusted()`; Accessibility is read via `isTrustedAccessibilityClient(false)`.
- Both rows' Settings buttons align flush by fixing the status label width (equalizes the Enabled/Disabled pill).

**Accessibility-access banner**
- Semantic markup (`section` labelled by an `h2#accessibility-access-needed`), color inversion, removed shield icon, icon/detail recolor, and hover states for the Grant/Scan buttons.
- Fixes the non-functional **Grant access** button: it now also opens System Settings → Privacy & Security → Accessibility. The native prompt (`requestPermission`) only appears once per app identity, so the direct deep link guarantees the click always has a visible effect.

**Versioning**
- Bumps the app version to **1.1.0**.

## Link to the Issue proposing these changes

**Required.**

N/A — no separate proposal Issue.

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes

Notes: This change is macOS-only — the banner renders only when `accessibility === 'denied'` (the Windows provider reports `not-required`), and the Permissions window and Automation probe are guarded to `darwin`. Verified on macOS via offscreen render harnesses (Grant-access click issues `requestPermission` then `openExternal` to the Accessibility pane; Settings buttons share identical left/right edges) and on the packaged, installed `.app` (rebuilt DMG, reinstalled, relaunched, Grant access confirmed to open System Settings). Not tested on Windows.