### PR TITLE
🤖 v1.2.1: sign macOS release DMGs (fix Accessibility grant persistence) + rework permissions banner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
     # Publish to the draft release only for tag builds; a manual run just packages.
     env:
       PUBLISH: ${{ startsWith(github.ref, 'refs/tags/') && 'always' || 'never' }}
+      # When the macOS self-signing secret is present, release DMGs are signed with
+      # a persistent self-signed identity so macOS TCC (Accessibility) grants survive
+      # updates. Absent (e.g. forks), the mac build falls back to ad-hoc.
+      HAS_MAC_CERT: ${{ secrets.MAC_SELFSIGN_P12_BASE64 != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,13 +66,49 @@ jobs:
         if: matrix.platform == 'win'
         run: npm run build:helper:win
 
+      - name: Import macOS signing certificate
+        if: matrix.platform == 'mac' && env.HAS_MAC_CERT == 'true'
+        env:
+          MAC_CERT_P12_BASE64: ${{ secrets.MAC_SELFSIGN_P12_BASE64 }}
+          MAC_CERT_PASSWORD: ${{ secrets.MAC_SELFSIGN_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/wcip-signing.keychain-db"
+          KEYCHAIN_PW="$(openssl rand -hex 20)"
+          CERT_PATH="$RUNNER_TEMP/wcip-cert.p12"
+
+          printf '%s' "$MAC_CERT_P12_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign -A
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PW" "$KEYCHAIN_PATH" >/dev/null
+          # Add the temp keychain to the search list so codesign (via afterSign) finds it.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/["]//g')
+          rm -f "$CERT_PATH"
+
+          # Sign by the 40-char SHA-1 hash (unambiguous) rather than the common name.
+          IDENTITY_HASH="$(security find-identity -p codesigning "$KEYCHAIN_PATH" | grep -Eo '[0-9A-F]{40}' | head -1)"
+          if [ -z "$IDENTITY_HASH" ]; then echo "No code-signing identity imported" >&2; exit 1; fi
+          echo "MAC_SIGN_IDENTITY=$IDENTITY_HASH" >> "$GITHUB_ENV"
+          echo "Imported signing identity $IDENTITY_HASH"
+
       - name: Package and publish macOS installers
         if: matrix.platform == 'mac'
         run: npx --no-install electron-builder --mac --universal --publish ${{ env.PUBLISH }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Ship unsigned for now; skip the signing-identity search on CI.
+          # electron-builder itself stays ad-hoc (no Developer ID auto-discovery);
+          # the afterSign hook applies the persistent self-signed identity below so
+          # the shipped app has a stable TCC designated requirement. Empty when the
+          # signing secret is absent, so afterSign no-ops and the build stays ad-hoc.
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+          SELF_SIGN_IDENTITY: ${{ env.MAC_SIGN_IDENTITY }}
+
+      - name: Remove signing keychain
+        if: always() && matrix.platform == 'mac' && env.HAS_MAC_CERT == 'true'
+        run: security delete-keychain "$RUNNER_TEMP/wcip-signing.keychain-db" 2>/dev/null || true
 
       - name: Package and publish Windows installer
         if: matrix.platform == 'win'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -11,7 +11,7 @@ import {
   Pin,
   Info
 } from 'lucide'
-import type { CoverageGap, PermissionStatus, ScanResult } from '@shared/scan'
+import type { CoverageGap, ScanResult } from '@shared/scan'
 import {
   comboTokens,
   formatCombo,
@@ -871,35 +871,53 @@ function renderAppSection(
   `
 }
 
-function renderBanner(permission: PermissionStatus): void {
-  if (permission.accessibility === 'denied') {
-    bannerEl.innerHTML = `
-      <section class="banner banner-warn" aria-labelledby="accessibility-access-needed">
-        <div class="banner-body">
-          <i data-lucide="triangle-alert" class="banner-icon" aria-hidden="true"></i>
-          <div>
-            <h2 id="accessibility-access-needed" class="banner-title">Accessibility access needed</h2>
-            <div class="banner-detail">${escapeHtml(permission.details ?? 'Grant access to read app menu shortcuts.')}</div>
-          </div>
-        </div>
-        <button class="secondary" id="grant">Grant access</button>
-      </section>
-    `
-    renderIcons(bannerEl)
-    const grant = document.getElementById('grant') as HTMLButtonElement
-    grant.addEventListener('click', async () => {
-      // requestPermission registers the app in the TCC Accessibility list and shows
-      // the native prompt on first run only; macOS never re-shows it once the app is
-      // listed, so also open the Accessibility pane directly so the click always has
-      // a visible effect and the user can toggle the grant.
-      await window.shortcutApi.requestPermission().catch(() => undefined)
-      await window.shortcutApi.openExternal(
-        'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
-      )
-    })
+const BANNER_DISMISSED_KEY = 'wcip:accessibility-banner-dismissed'
+
+/**
+ * Accessibility banner. Rendered once at launch on macOS and shown until the user
+ * dismisses it; the dismissal persists in localStorage so it never returns. It is
+ * decoupled from scan/permission state, so it no longer appears only after a scan
+ * nor flickers as the result re-renders on every filter keystroke.
+ */
+function renderPermissionBanner(): void {
+  const dismissed = localStorage.getItem(BANNER_DISMISSED_KEY) === '1'
+  if (readerPlatform !== 'darwin' || dismissed) {
+    bannerEl.innerHTML = ''
     return
   }
-  bannerEl.innerHTML = ''
+  bannerEl.innerHTML = `
+    <section class="banner banner-warn" aria-labelledby="accessibility-access-needed">
+      <button class="banner-dismiss" id="banner-dismiss" type="button" aria-label="Dismiss">
+        <i data-lucide="x" aria-hidden="true"></i>
+      </button>
+      <div class="banner-body">
+        <i data-lucide="triangle-alert" class="banner-icon" aria-hidden="true"></i>
+        <div class="banner-text">
+          <h2 id="accessibility-access-needed" class="banner-title">Accessibility access needed</h2>
+          <div class="banner-detail">Grant access to read app menu shortcuts.</div>
+          <button class="secondary" id="grant">Grant access</button>
+        </div>
+      </div>
+    </section>
+  `
+  renderIcons(bannerEl)
+  const grant = document.getElementById('grant') as HTMLButtonElement
+  grant.addEventListener('click', async () => {
+    // requestPermission registers the app in the TCC Accessibility list and shows
+    // the native prompt on first run only; macOS never re-shows it once the app is
+    // listed, so also open the Accessibility pane directly so the click always has
+    // a visible effect and the user can toggle the grant.
+    await window.shortcutApi.requestPermission().catch(() => undefined)
+    await window.shortcutApi.openExternal(
+      'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
+    )
+  })
+  const dismiss = document.getElementById('banner-dismiss') as HTMLButtonElement
+  dismiss.addEventListener('click', () => {
+    localStorage.setItem(BANNER_DISMISSED_KEY, '1')
+    bannerEl.innerHTML = ''
+    scanButton.focus()
+  })
 }
 
 function emptyFilterMessage(query: string): string {
@@ -1009,8 +1027,6 @@ function renderResult(): void {
   content.classList.remove('is-empty')
   searchCount.textContent = resultsLabel(visible.length)
   searchCount.hidden = query.length === 0 || visible.length === 0
-
-  if (lastResult) renderBanner(lastResult.permission)
 
   if (base.length === 0) {
     content.innerHTML = `${CONTENT_HEADING}<div class="empty-state"><div>No reserved shortcuts found.</div></div>`
@@ -1617,6 +1633,7 @@ async function initReaderSections(): Promise<void> {
   } catch {
     readerShortcuts = []
   }
+  renderPermissionBanner()
   if (!lastResult) renderResult()
 }
 void initReaderSections()

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -894,7 +894,7 @@ function renderPermissionBanner(): void {
         <i data-lucide="triangle-alert" class="banner-icon" aria-hidden="true"></i>
         <div class="banner-text">
           <h2 id="accessibility-access-needed" class="banner-title">Accessibility access needed</h2>
-          <div class="banner-detail">Grant access to read app menu shortcuts.</div>
+          <div class="banner-detail">Permission need to scan app shortcuts.</div>
           <button class="secondary" id="grant">Grant access</button>
         </div>
       </div>

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -894,7 +894,7 @@ function renderPermissionBanner(): void {
         <i data-lucide="triangle-alert" class="banner-icon" aria-hidden="true"></i>
         <div class="banner-text">
           <h2 id="accessibility-access-needed" class="banner-title">Accessibility access needed</h2>
-          <div class="banner-detail">Permission need to scan app shortcuts.</div>
+          <div class="banner-detail">Permission needed to scan app shortcuts.</div>
           <button class="secondary" id="grant">Grant access</button>
         </div>
       </div>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -616,15 +616,36 @@ html[data-input='keyboard'] .row-button:focus {
 }
 
 .banner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin: 10px 14px;
-  padding: 10px 12px;
-  border-radius: 8px;
+  position: relative;
+  padding: 12px 42px 12px 14px;
   font-size: 12px;
   color: var(--bg);
+}
+
+.banner-dismiss {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--bg);
+  cursor: pointer;
+}
+
+.banner-dismiss:hover {
+  background: color-mix(in srgb, var(--bg) 18%, transparent);
+}
+
+.banner-dismiss svg {
+  width: 16px;
+  height: 16px;
 }
 
 .banner-warn {
@@ -635,6 +656,10 @@ html[data-input='keyboard'] .row-button:focus {
   display: flex;
   align-items: flex-start;
   gap: 10px;
+}
+
+.banner-text {
+  min-width: 0;
 }
 
 .banner-icon {
@@ -650,6 +675,7 @@ html[data-input='keyboard'] .row-button:focus {
   align-items: center;
   gap: 6px;
   flex: none;
+  margin-top: 8px;
 }
 
 #grant svg {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -676,6 +676,8 @@ html[data-input='keyboard'] .row-button:focus {
   gap: 6px;
   flex: none;
   margin-top: 8px;
+  padding: 4px 10px;
+  font-size: 11px;
 }
 
 #grant svg {


### PR DESCRIPTION
## Describe your proposed changes

### 1. Sign macOS release DMGs with a persistent self-signed identity

**Root cause (proven via macOS `tccd` logs + signature inspection of the shipped v1.2.0 DMG).** Released builds were ad-hoc/linker-signed (`Identifier=Electron`, `flags=0x20002(adhoc,linker-signed)`, no designated requirement). macOS TCC pins each Accessibility grant to the app's code-signing designated requirement (DR). An ad-hoc binary has no stable DR, so every install recorded a grant the next build could not match — `tccd` logged `Failed to match existing code requirement for subject com.ericwbailey.whatcantipress and service kTCCServiceAccessibility`, and `AXIsProcessTrusted()` returned false even with the System Settings switch ON. That is why the light stayed red and only global/symbolic shortcuts scanned.

**Fix.** Sign published macOS installers with a persistent self-signed code-signing identity so the app carries a stable DR (`identifier + certificate leaf`) that survives updates:

- `release.yml` imports a reusable self-signed cert (new repo secrets `MAC_SELFSIGN_P12_BASE64` / `MAC_SELFSIGN_P12_PASSWORD`) into a temporary keychain, then hands its identity to the existing `afterSign.js` hook via `SELF_SIGN_IDENTITY` (signed by 40-char SHA-1 hash, unambiguous). The temp keychain is removed afterwards.
- When the secret is absent (e.g. forks), the mac build falls back to ad-hoc — unchanged behavior.
- Bump to 1.2.1.

**Verification (shipped artifact, not the dev runner).**
- macOS `tccd` log on a stable-identity build: `matchesCodeRequirement … certificate leaf = H"…"; status: 0` + `Auth Right: Allowed`, across 3 consecutive launches, zero mismatches; on-screen light GREEN and shortcut list populated.
- Real CI dry-run (`workflow_dispatch`) built `WhatCantIPress-1.2.1-universal.dmg`; inspecting the runner-produced app: `Identifier=com.ericwbailey.whatcantipress`, `flags=0x10000(runtime)`, `Authority=What Cant I Press Dev`, `designated => identifier "com.ericwbailey.whatcantipress" and certificate leaf = H"d636a7a78…"`; nested helper signed with the same leaf; `codesign --verify --deep --strict` → valid, satisfies its Designated Requirement.

**Tradeoff (self-signed, not notarized).** First launch of a downloaded build shows Gatekeeper's "unidentified developer" and needs one right-click → Open. Moving from the current ad-hoc install to 1.2.1 needs one remove/re-add of the Accessibility grant (the DR changes once); it persists across every release afterward.

### 2. Rework the permissions banner UX

Rework the macOS "Accessibility access needed" banner (renderer-only; no main-process or IPC change):

- **Always-on until dismissed.** Rendered once at launch (macOS only) via `renderPermissionBanner()`, decoupled from scan/permission state — it no longer appears only after a scan nor flickers as the results re-render on every filter keystroke. Dismissal persists in `localStorage` (`wcip:accessibility-banner-dismissed`) and never returns.
- **Full width.** The banner spans edge-to-edge (drops the horizontal margin and border-radius).
- **Dismiss button.** A top-right Lucide `x` (`aria-label="Dismiss"`, no `title`/`data-tip`, so no hover/focus tooltip) clears the banner and moves focus to the scan button.
- **Copy + sizing.** Detail text reads "Permission needed to scan app shortcuts."; the "Grant access" button is smaller (font-size/padding scoped to `#grant`, so the footer scan buttons are unchanged).

**Verification** via an offscreen Electron renderer harness (built `out/renderer`, CSP stripped, `window.shortcutApi` mocked): banner present at launch on macOS, full-width (measured banner width = app width), dismiss sets the flag + clears + refocuses, dismissal persists across reload, and the banner is not shown on Windows. `npm run typecheck` + `npm run build` clean.

## Link to the Issue proposing these changes

N/A

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes