### PR TITLE
🤖 Fix macOS permissions banner persisting across reinstalls and last-focused-app scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/main/core/scan-runner.ts
+++ b/src/main/core/scan-runner.ts
@@ -20,30 +20,61 @@ function delay(ms: number): Promise<void> {
 }
 
 /**
+ * Resolves the app a frontmost-only scan should target. Prefers the app captured
+ * before our popover stole focus (`currentApp`); otherwise queries the live
+ * frontmost app. Never returns our own process: right after the launch reveal the
+ * popover is frontmost, and reading its (empty accessory) menu would make a scan
+ * look like it found only OS shortcuts. Returns null when the only candidate is
+ * ourselves or nothing is frontmost.
+ */
+async function resolveFrontmostTarget(
+  provider: PlatformProvider,
+  currentApp?: RunningApp | null
+): Promise<RunningApp | null> {
+  if (currentApp && currentApp.pid !== process.pid) return currentApp
+  const live = await provider.getFrontmostApp()
+  if (live && live.pid !== process.pid) return live
+  return null
+}
+
+/**
  * Reads the target app's menus only (quick, non-disruptive). The target is the
  * app that was frontmost when the popover opened (`currentApp`); falls back to
  * the live frontmost app when no capture is available. Reading is by pid via
  * Accessibility and does not require the app to be frontmost, so nothing flashes.
+ *
+ * `targetName` is the resolved app's name (even for a screen reader, whose
+ * shortcuts come from the curated set rather than its menu bar), or null when no
+ * valid non-self app was frontmost — the signal the renderer uses to prompt the
+ * user to focus an app and rescan.
  */
 async function scanFrontmostOnly(
   provider: PlatformProvider,
   onProgress: ProgressReporter,
   cancel: Cancellation,
   currentApp?: RunningApp | null
-): Promise<{ raws: RawShortcut[]; appsScanned: number; gaps: CoverageGap[] }> {
-  if (cancel.cancelled) return { raws: [], appsScanned: 0, gaps: [] }
-  const frontmost = currentApp ?? (await provider.getFrontmostApp())
-  if (!frontmost) return { raws: [], appsScanned: 0, gaps: [] }
-  // A screen reader is surfaced from the curated set, not its menu bar.
-  if (isScreenReaderApp(frontmost)) return { raws: [], appsScanned: 0, gaps: [] }
+): Promise<{
+  raws: RawShortcut[]
+  appsScanned: number
+  gaps: CoverageGap[]
+  targetName: string | null
+}> {
+  if (cancel.cancelled) return { raws: [], appsScanned: 0, gaps: [], targetName: null }
+  const frontmost = await resolveFrontmostTarget(provider, currentApp)
+  if (!frontmost) return { raws: [], appsScanned: 0, gaps: [], targetName: null }
+  // A screen reader is surfaced from the curated set, not its menu bar; it is
+  // still a valid focused app, so report its name so no "focus an app" hint shows.
+  if (isScreenReaderApp(frontmost)) {
+    return { raws: [], appsScanned: 0, gaps: [], targetName: frontmost.name }
+  }
 
   onProgress({ phase: 'apps', current: 1, total: 1, appName: frontmost.name })
   try {
     const raws = await provider.readAppMenuShortcuts(frontmost)
     const gaps = await provider.readCoverageGaps(frontmost)
-    return { raws, appsScanned: 1, gaps }
+    return { raws, appsScanned: 1, gaps, targetName: frontmost.name }
   } catch {
-    return { raws: [], appsScanned: 0, gaps: [] }
+    return { raws: [], appsScanned: 0, gaps: [], targetName: frontmost.name }
   }
 }
 
@@ -139,15 +170,21 @@ export async function runScan(
   const accessibilityBlocked = permission.accessibility === 'denied'
 
   let appsScanned = 0
+  let frontmostAppName: string | null = null
   const coverageGaps: CoverageGap[] = []
   if (!cancel.cancelled && !accessibilityBlocked) {
-    const result =
-      options.scanAllApps && apps.length > 0
-        ? await scanAllApps(provider, apps, onProgress, cancel, currentApp)
-        : await scanFrontmostOnly(provider, onProgress, cancel, currentApp)
-    raws.push(...result.raws)
-    appsScanned = result.appsScanned
-    coverageGaps.push(...result.gaps)
+    if (options.scanAllApps && apps.length > 0) {
+      const result = await scanAllApps(provider, apps, onProgress, cancel, currentApp)
+      raws.push(...result.raws)
+      appsScanned = result.appsScanned
+      coverageGaps.push(...result.gaps)
+    } else {
+      const result = await scanFrontmostOnly(provider, onProgress, cancel, currentApp)
+      raws.push(...result.raws)
+      appsScanned = result.appsScanned
+      coverageGaps.push(...result.gaps)
+      frontmostAppName = result.targetName
+    }
   }
 
   onProgress({ phase: 'curated' })
@@ -167,6 +204,7 @@ export async function runScan(
     permission,
     shortcuts,
     appsScanned,
+    frontmostAppName,
     coverageGaps: dedupeGaps(coverageGaps)
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -154,7 +154,7 @@ if (!gotSingleInstanceLock) app.quit()
 app.on('second-instance', () => void reopenPopover())
 app.on('activate', () => void reopenPopover())
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   if (!gotSingleInstanceLock) return
   log(`App ready (log file: ${logFilePath()})`)
 
@@ -192,7 +192,10 @@ app.whenReady().then(() => {
 
   // Menu-bar-only apps start with no visible window; a missing or notch-hidden
   // status item then leaves nothing to click. Reveal the popover on every launch
-  // so opening the app always surfaces it.
+  // so opening the app always surfaces it. Capture the frontmost app first —
+  // before the reveal steals focus — so a "Scan last focused app" run right after
+  // launch targets the app the user was using rather than What Can't I Press.
+  await captureForegroundApp()
   log('Launch: revealing popover')
   showPopover()
 

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -943,6 +943,7 @@ function renderPermissionBanner(): void {
  * banner does not flash.
  */
 async function refreshAccessibilityBanner(): Promise<void> {
+  const prevGranted = accessibilityGranted
   if (readerPlatform === 'darwin') {
     try {
       const status = await window.shortcutApi.getPermissionStatus()
@@ -952,6 +953,12 @@ async function refreshAccessibilityBanner(): Promise<void> {
     }
   }
   renderPermissionBanner()
+  // A grant change flips whether the scan hint is allowed to show; the hint lives
+  // in #content, which this focus/launch path does not otherwise re-render. Re-run
+  // it only on an actual change (and only with a result on screen) so a stale hint
+  // clears on revoke — and a now-appropriate one appears on grant — without
+  // churning #content (and resetting scroll) on every ordinary focus.
+  if (accessibilityGranted !== prevGranted && lastResult) renderResult()
 }
 
 function emptyFilterMessage(query: string): string {
@@ -1050,17 +1057,50 @@ function stopScanningHeartbeat(): void {
   scanningHeartbeatTimer = undefined
 }
 
+/** Whether the scan hint was dismissed for the current launch only. In-memory,
+ * never persisted — so it returns on the next launch, matching the accessibility
+ * banner. Not reset by scans or filtering within a launch. */
+let scanHintDismissed = false
+
+const SCAN_HINT_MARKUP =
+  '<div class="scan-hint">' +
+  '<i data-lucide="info" aria-hidden="true"></i>' +
+  '<p class="scan-hint-text">Focus the app you want to check, then rescan.</p>' +
+  '<button class="scan-hint-dismiss" id="scan-hint-dismiss" type="button" aria-label="dismiss"><i data-lucide="x" aria-hidden="true"></i></button>' +
+  '</div>'
+
 /**
  * Inline hint shown after a frontmost-only scan that resolved no app to read —
  * e.g. right after launch when What Can't I Press itself was frontmost and no
- * prior app had been captured. Only shown when Accessibility is not the blocker
- * (the banner covers that) and the scan was not a scan-all sweep.
+ * prior app had been captured. On macOS it shows only when Accessibility is
+ * actually granted (the live grant, shared with the permission banner) so the two
+ * never collide: when access is missing the banner owns the message, and its
+ * "rescan" advice would be misleading while the grant — not focus — is the blocker.
+ * Off macOS accessibility is not required, so that gate is skipped. Not shown for a
+ * scan-all sweep. Dismissible for the current launch via #scan-hint-dismiss.
  */
 function scanHintHtml(): string {
+  if (scanHintDismissed) return ''
   if (!lastResult || lastScanAll) return ''
-  if (lastResult.permission.accessibility === 'denied') return ''
+  if (readerPlatform === 'darwin' && accessibilityGranted !== true) return ''
   if (lastResult.frontmostAppName != null) return ''
-  return `<div class="scan-hint"><i data-lucide="info" aria-hidden="true"></i><p class="scan-hint-text">Focus the app you want to check, then rescan.</p></div>`
+  return SCAN_HINT_MARKUP
+}
+
+/**
+ * Wires the scan hint's dismiss button, present only on the passes where the hint
+ * renders. Dismissal lasts the current launch — held in scanHintDismissed, never
+ * persisted — so the hint returns on the next launch (matching the accessibility
+ * banner). Focus moves to the scan button, mirroring the banner's dismiss.
+ */
+function wireScanHintDismiss(): void {
+  const dismiss = document.getElementById('scan-hint-dismiss') as HTMLButtonElement | null
+  if (!dismiss) return
+  dismiss.addEventListener('click', () => {
+    scanHintDismissed = true
+    content.querySelector('.scan-hint')?.remove()
+    scanButton.focus()
+  })
 }
 
 function renderResult(): void {
@@ -1100,6 +1140,7 @@ function renderResult(): void {
     : `${CONTENT_HEADING}${scanHintHtml()}${sections}${gapsHtml}`
   renderIcons(content)
   wireSectionJumps(content)
+  wireScanHintDismiss()
 }
 
 /**

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -251,6 +251,15 @@ let readerShortcuts: Shortcut[] = []
 let readerPlatform: Platform = 'darwin'
 /** True until the first scan clears the launch-time collapsed seeding. */
 let seededReaderCollapse = false
+/**
+ * Last known live Accessibility grant (macOS): true granted, false denied, null
+ * until first probed. Drives the permission banner. Refreshed at launch, on window
+ * focus, and after each scan — never on filter keystrokes — so the banner reflects
+ * real state without flickering.
+ */
+let accessibilityGranted: boolean | null = null
+/** Whether the most recent scan was a scan-all sweep (vs frontmost-only). */
+let lastScanAll = false
 
 function escapeHtml(value: string): string {
   return value
@@ -871,17 +880,24 @@ function renderAppSection(
   `
 }
 
-const BANNER_DISMISSED_KEY = 'wcip:accessibility-banner-dismissed'
+/** Whether the accessibility banner was dismissed for the current launch only. */
+let bannerDismissedThisLaunch = false
 
 /**
- * Accessibility banner. Rendered once at launch on macOS and shown until the user
- * dismisses it; the dismissal persists in localStorage so it never returns. It is
- * decoupled from scan/permission state, so it no longer appears only after a scan
- * nor flickers as the result re-renders on every filter keystroke.
+ * Accessibility banner. Driven by the live Accessibility grant: shown on macOS
+ * whenever access is not granted, and hidden as soon as it is. Because it reflects
+ * real permission state rather than a persisted flag, it returns on a fresh
+ * install (and whenever access is later revoked) and never lingers once access is
+ * granted. Dismissal lasts only for the current launch — held in memory, never
+ * persisted — so the banner reappears next launch if access is still missing (and
+ * so a stale "dismissed" flag can no longer survive an uninstall/reinstall). It is
+ * re-rendered only on discrete events (launch, window focus, after a scan), never
+ * on filter keystrokes, so it does not flicker as results re-render.
  */
 function renderPermissionBanner(): void {
-  const dismissed = localStorage.getItem(BANNER_DISMISSED_KEY) === '1'
-  if (readerPlatform !== 'darwin' || dismissed) {
+  const show =
+    readerPlatform === 'darwin' && accessibilityGranted === false && !bannerDismissedThisLaunch
+  if (!show) {
     bannerEl.innerHTML = ''
     return
   }
@@ -914,10 +930,28 @@ function renderPermissionBanner(): void {
   })
   const dismiss = document.getElementById('banner-dismiss') as HTMLButtonElement
   dismiss.addEventListener('click', () => {
-    localStorage.setItem(BANNER_DISMISSED_KEY, '1')
+    bannerDismissedThisLaunch = true
     bannerEl.innerHTML = ''
     scanButton.focus()
   })
+}
+
+/**
+ * Probes the live Accessibility grant and re-renders the banner. Called at launch
+ * and on window focus (covering the return from System Settings after "Grant
+ * access"). A transient probe failure leaves the last known state untouched so the
+ * banner does not flash.
+ */
+async function refreshAccessibilityBanner(): Promise<void> {
+  if (readerPlatform === 'darwin') {
+    try {
+      const status = await window.shortcutApi.getPermissionStatus()
+      accessibilityGranted = status.accessibility === 'granted'
+    } catch {
+      // Keep the previous value; do not show a false alarm on a probe failure.
+    }
+  }
+  renderPermissionBanner()
 }
 
 function emptyFilterMessage(query: string): string {
@@ -1016,6 +1050,19 @@ function stopScanningHeartbeat(): void {
   scanningHeartbeatTimer = undefined
 }
 
+/**
+ * Inline hint shown after a frontmost-only scan that resolved no app to read —
+ * e.g. right after launch when What Can't I Press itself was frontmost and no
+ * prior app had been captured. Only shown when Accessibility is not the blocker
+ * (the banner covers that) and the scan was not a scan-all sweep.
+ */
+function scanHintHtml(): string {
+  if (!lastResult || lastScanAll) return ''
+  if (lastResult.permission.accessibility === 'denied') return ''
+  if (lastResult.frontmostAppName != null) return ''
+  return `<div class="scan-hint"><i data-lucide="info" aria-hidden="true"></i><p class="scan-hint-text">Focus the app you want to check, then rescan.</p></div>`
+}
+
 function renderResult(): void {
   chordBar.hidden = false
   hideTip()
@@ -1050,7 +1097,7 @@ function renderResult(): void {
   content.classList.toggle('is-empty', preScan)
   content.innerHTML = preScan
     ? `${CONTENT_HEADING}${sections}<div class="scan-note"><i data-lucide="info" aria-hidden="true"></i><p class="scan-note-text">What Can't I Press cannot detect all possible keyboard shortcuts. Be sure to also check manually.</p></div>`
-    : `${CONTENT_HEADING}${sections}${gapsHtml}`
+    : `${CONTENT_HEADING}${scanHintHtml()}${sections}${gapsHtml}`
   renderIcons(content)
   wireSectionJumps(content)
 }
@@ -1217,6 +1264,14 @@ async function runScan(scanAllApps: boolean): Promise<void> {
   startScanningHeartbeat()
   try {
     lastResult = await window.shortcutApi.scan({ scanAllApps })
+    lastScanAll = scanAllApps
+    // The scan result carries the authoritative permission state; sync the banner
+    // from it so granting access then scanning hides the banner (and a denial
+    // reveals it) without waiting for a focus event.
+    if (readerPlatform === 'darwin') {
+      accessibilityGranted = lastResult.permission.accessibility === 'granted'
+      renderPermissionBanner()
+    }
     if (seededReaderCollapse) {
       for (const name of READER_APP_NAMES) collapsedSegments.delete(`screen-reader:${name}`)
       seededReaderCollapse = false
@@ -1616,8 +1671,13 @@ content.addEventListener('click', (event) => {
 })
 
 // Focus the primary action on load and each time the popover regains focus,
-// so opening the menu-bar window always lands on "Scan last focused app".
-window.addEventListener('focus', () => scanButton.focus())
+// so opening the menu-bar window always lands on "Scan last focused app". Also
+// re-probe Accessibility so the banner reflects a grant made in System Settings
+// while the popover was hidden.
+window.addEventListener('focus', () => {
+  scanButton.focus()
+  void refreshAccessibilityBanner()
+})
 scanButton.focus()
 
 // Always show the screen-reader sections, even before a scan. Seed them
@@ -1634,6 +1694,7 @@ async function initReaderSections(): Promise<void> {
     readerShortcuts = []
   }
   renderPermissionBanner()
+  void refreshAccessibilityBanner()
   if (!lastResult) renderResult()
 }
 void initReaderSections()

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -757,7 +757,7 @@ main.is-empty .segment-wrap {
   align-items: center;
   gap: 10px;
   margin: 0 -14px 10px;
-  padding: 12px 14px;
+  padding: 8px 14px;
   background: var(--text);
   color: var(--bg);
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -749,6 +749,33 @@ main.is-empty .segment-wrap {
   line-height: 1.4;
 }
 
+/* Inline hint above scan results when no last-focused app could be read. Unlike
+   the centered pre-scan .scan-note, this is a compact top-of-list row. */
+.scan-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text-dim);
+}
+
+.scan-hint svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  color: var(--scan-note-icon);
+}
+
+.scan-hint-text {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .segment {
   margin-top: 0;
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -750,30 +750,51 @@ main.is-empty .segment-wrap {
 }
 
 /* Inline hint above scan results when no last-focused app could be read. Unlike
-   the centered pre-scan .scan-note, this is a compact top-of-list row. */
+   the centered pre-scan .scan-note, this is a full-bleed top-of-list row that
+   reuses the accessibility banner's color treatment (var(--text) on var(--bg)). */
 .scan-hint {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 8px 0 10px;
-  padding: 8px 12px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  color: var(--text-dim);
+  gap: 10px;
+  margin: 0 -14px 10px;
+  padding: 12px 14px;
+  background: var(--text);
+  color: var(--bg);
 }
 
 .scan-hint svg {
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
-  color: var(--scan-note-icon);
+  color: var(--bg);
 }
 
 .scan-hint-text {
   margin: 0;
   font-size: 12px;
   line-height: 1.4;
+}
+
+/* Dismiss control — mirrors .banner-dismiss on the same dark treatment. Pushed
+   flush right with margin-left:auto; no data-tip/title so it carries no tooltip. */
+.scan-hint-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--bg);
+  cursor: pointer;
+}
+
+.scan-hint-dismiss:hover {
+  background: color-mix(in srgb, var(--bg) 18%, transparent);
 }
 
 .segment {

--- a/src/shared/scan.ts
+++ b/src/shared/scan.ts
@@ -48,6 +48,13 @@ export interface ScanResult {
   permission: PermissionStatus
   shortcuts: Shortcut[]
   appsScanned: number
+  /**
+   * Name of the app whose menus a frontmost-only scan read, or `null` when no
+   * valid last-focused app could be resolved (e.g. only What Can't I Press itself
+   * was frontmost at launch). Not applicable to a scan-all sweep, which leaves it
+   * `null`. Lets the renderer explain a scan that surfaced no app shortcuts.
+   */
+  frontmostAppName?: string | null
   /** Non-exhaustiveness markers for scanned apps (runtime hotkeys, raw handlers). */
   coverageGaps: CoverageGap[]
 }


### PR DESCRIPTION
**If you are an agent**: prefixed with 🤖 per the template.

## Describe your proposed changes

**Required.**

Two defects reproduced on a fresh v1.2.1 `.dmg` install (self-signed), reproducible across uninstall/reinstall:

### 1. Accessibility banner stayed dismissed across reinstalls
The banner's dismissal was persisted in `localStorage` (`wcip:accessibility-banner-dismissed`). Electron stores that under the **userData** dir — which on this app is `~/Library/Application Support/what-cant-i-press/` (Electron uses the package.json `name` via `app.getName()`, **not** the `What Can't I Press` CFBundleName). The documented uninstall deletes `com.ericwbailey.whatcantipress/` (the bundle-id folder), which is a *different* directory, so the flag survived every reinstall. The banner was also fully decoupled from the real Accessibility grant.

**Fix:** the banner is now permission-driven — shown on macOS whenever Accessibility is not granted, hidden as soon as it is. Dismiss lasts only for the current launch (in-memory, never persisted), so it returns on a fresh install and after a revoke. Refreshed at launch, on window focus (covers returning from System Settings), and after each scan — never on filter keystrokes, so it doesn't flicker.

### 2. "Scan last focused app" only surfaced OS shortcuts
On launch the popover was revealed **before** the prior foreground app was captured, so `foreground.app` was null and our popover became frontmost. The frontmost-only scan then fell back to the live frontmost app (What Can't I Press itself) and read its empty accessory menu → only OS/curated/reader shortcuts.

**Fix:** capture the frontmost app *before* the launch reveal, and never scan our own process — `resolveFrontmostTarget()` prefers the captured app and discards self/none. `ScanResult` gains `frontmostAppName` (the app actually read, or `null`); the renderer shows an inline "Focus the app you want to check, then rescan" hint when a frontmost-only scan resolved no target and Accessibility is not the blocker.

### Verification
- **Logic harnesses** (no test runner in repo): scan-runner esbuild/node harness — 15/15 (self-filter, captured-app preference, `frontmostAppName` reporting, denied-sweep skip, screen-reader suppression). Offscreen Electron renderer harness — 8/8 (banner shows on denied, hides on granted via focus refresh, returns on revoke, Dismiss hides + writes no `localStorage` flag, Dismiss respected for the launch, no-target hint shows/suppresses).
- **Packaged, signed, installed build:** built `build:mac:signed` (electron-builder ad-hoc + `afterSign` re-sign with a persistent self-signed identity — same path as the shipped DMG; arm64 vs the release's universal). Installed to `/Applications`, verified stable Designated Requirement, launched **3× cold on the real user-data profile** — popover appeared on-screen top-right (identical pos/size each launch) with the **"Accessibility access needed" banner rendered**, even though the stale `wcip:accessibility-banner-dismissed` flag was still present in the leveldb (old code would have hidden it — direct on-screen proof of the fix).
- **Handed off (cannot be done from the CLI):** clicking "Scan last focused app" / granting Accessibility requires synthesized input that needs an Accessibility grant the CLI process lacks, so the end-to-end *scan reads the last app's menus* path was proven by harness + on-screen banner, not by an on-screen scan. A physically notch-hidden / overflowed menu-bar item also cannot be reproduced here.

**Note for clean reinstall testing:** also delete `~/Library/Application Support/what-cant-i-press/` — that is the real userData dir; the previous uninstall list never removed it.

## Link to the Issue proposing these changes

**Required.**

N/A — filed directly from a maintainer bug report (fresh `.dmg` install on a separate machine). Happy to open a tracking Issue if preferred.

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS (packaged signed build, 3× on the real profile; end-to-end scan click handed off — see Verification)
- [ ] I have created an Issue to propose these changes

---

## Follow-up changes on this branch (v1.2.2)

- Restyled the "Focus the app you want to check, then rescan." hint to match the Accessibility banner — full-width dark bar, no border or rounded corners, tighter vertical padding — and added a per-launch dismiss button (Lucide `x`, `aria-label="dismiss"`, no tooltip; returns on the next launch).
- Fixed a collision where the permission banner and that hint could show at the same time: the hint now follows the **live** Accessibility grant (darwin-scoped) instead of the frozen scan result, and `#content` re-renders on an actual grant change, so revoking access clears the stale hint and shows the banner. Verified via the offscreen renderer harness (now **16/16**); the on-screen check on a signed build (real TCC toggle + focus) is a manual step the CLI can't synthesize.
- Bumped version to **1.2.2**.
