### PR TITLE
🤖 Serialize release matrix so a tag publishes one draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
   release:
     strategy:
       fail-fast: false
+      # Run the platforms one at a time so the first build creates the draft
+      # GitHub Release and the second reuses it. Publishing both in parallel races
+      # electron-builder into creating two separate drafts (one per platform).
+      max-parallel: 1
       matrix:
         include:
           - os: macos-14


### PR DESCRIPTION
## Problem

Pushing a version tag builds the macOS and Windows installers as two parallel matrix jobs, each running `electron-builder --publish always`. When both run at the same moment, neither finds an existing GitHub Release for the tag yet, so **each creates its own draft** — one holding the `.dmg`, the other the `.exe`. This happened for `v1.2.2` (two drafts). Earlier releases (e.g. `v1.2.1`) only came out as a single release because the two jobs happened to finish far enough apart that the second reused the first's draft.

## Fix

Set `strategy.max-parallel: 1` on the `release` job so the two platforms run one at a time. The first build creates the draft release; the second finds and reuses it. Result: a single draft holding both installers plus the `latest.yml` / `latest-mac.yml` updater metadata — matching the `v1.2.1` layout.

- No behavioral change to signing, publishing, or the manual (`workflow_dispatch`) path.
- Trade-off: the two platforms no longer build concurrently, so a release run takes longer.

## Not covered by this change

The two `v1.2.2` drafts that already exist are not affected. One-time cleanup: delete both drafts, then re-run the release workflow for `v1.2.2` — it will rebuild a single draft on its own.