### PR TITLE
🤖 Store userData under the bundle id for clean uninstalls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,6 @@
 import { app, Menu, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { existsSync, renameSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
 import { IPC, type MenuCommand } from '@shared/ipc'
 import { createTrayIcon } from './icon'
 import {
@@ -143,6 +145,27 @@ function showTrayMenu(): void {
   ]
   tray.popUpContextMenu(Menu.buildFromTemplate(template))
 }
+
+// Store all persisted state under the bundle identifier so third-party
+// uninstallers, which match an app's associated files by its bundle id, remove
+// that state cleanly. Electron's default userData folder is named after
+// package.json `name` (`what-cant-i-press`), which matches neither the bundle id
+// nor the product name and is otherwise left behind on uninstall. Must run
+// before any userData access; logging is deferred until after `whenReady`.
+function consolidateUserDataUnderBundleId(): void {
+  const target = join(app.getPath('appData'), 'com.ericwbailey.whatcantipress')
+  const legacy = join(app.getPath('appData'), 'what-cant-i-press')
+  if (existsSync(legacy)) {
+    try {
+      if (existsSync(target)) rmSync(legacy, { recursive: true, force: true })
+      else renameSync(legacy, target)
+    } catch {
+      // Best-effort migration: fall back to the bundle-id path regardless.
+    }
+  }
+  app.setPath('userData', target)
+}
+consolidateUserDataUnderBundleId()
 
 // Single-instance guard: reopening the app from Applications/Finder while it is
 // already running in the menu bar must surface the existing window instead of


### PR DESCRIPTION
## Describe your proposed changes

**Required.**

Third-party uninstallers (AppDelete, AppCleaner, CleanMyMac) locate an app's associated files by matching the bundle id, product name, or executable name against names under `~/Library`. Electron's default userData folder is named after `package.json` `name` — `what-cant-i-press` — which matches none of this app's identity strings (`com.ericwbailey.whatcantipress`, `What Can't I Press`, `WhatCantIPress`). That folder holds the accessibility-banner dismissal flag and `logs/`, so it is left behind on uninstall and its stale state survives reinstalls.

This change, in `src/main/index.ts`, before any userData access:

- Rebinds userData to `<appData>/com.ericwbailey.whatcantipress` via `app.setPath('userData', …)`, so all persisted state lives under the bundle id every uninstaller matches with certainty.
- Migrates the existing folder in place: rename `what-cant-i-press` → `com.ericwbailey.whatcantipress` when the target is absent; remove the legacy copy when both exist. No data is orphaned during the transition, and the misnamed folder that survived prior uninstalls is collapsed.

macOS has no OS-level uninstall manifest — an app cannot declare a removal list — so aligning the folder name is the only mechanism available to these tools. The other state paths (`Preferences/com.ericwbailey.whatcantipress.plist`, `Saved Application State`, `HTTPStorages`, `WebKit`, `Caches`) are already bundle-id-named and were never the gap.

## Link to the Issue proposing these changes

**Required.**

N/A — follow-up to the reported macOS behavior where banner-dismissal state persisted across uninstall/reinstall because the userData folder was not removed. No separate Issue filed.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes

### Verification scope

Done: `typecheck:node` + `typecheck:web` pass; `electron-vite build` succeeds and the emitted `out/main/index.js` contains the `setPath("userData", …)` rebind (not tree-shaken); the migration decision tree was unit-tested against temp dirs for all three cases (rename when target absent, remove-legacy when both exist, no-op when legacy absent).

Not done: packaged `.dmg` install with a multi-launch on-screen run, and any Windows packaging/run. The path rebind and rename are cross-platform, but only the macOS `~/Library/Application Support` case was exercised, and not on a real installed build.