### PR TITLE
🤖 Return focus to the app after a scan completes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,7 +7,7 @@ import { runScan, type Cancellation } from './core/scan-runner'
 import { aggregate } from './core/aggregate'
 import { getScreenReaderShortcuts } from './core/screen-readers'
 import { foreground } from './core/foreground'
-import { popoverState, setScanning, setPinned } from './window'
+import { popoverState, setScanning, setPinned, activatePopover } from './window'
 
 const ALLOWED_EXTERNAL = /^(https?:|x-apple\.systempreferences:|ms-settings:)/i
 
@@ -72,7 +72,13 @@ export function registerIpc(getWindow: () => BrowserWindow | null): void {
         foreground.app
       )
     } finally {
-      if (sweeping && win) setScanning(win, false)
+      // A scan-all sweep activates each scanned app and then restores the app that
+      // was frontmost before it, leaving What Can't I Press in the background;
+      // bring it back to the foreground so focus returns to the popover.
+      if (sweeping && win) {
+        setScanning(win, false)
+        activatePopover(win)
+      }
       activeCancel = null
     }
   })

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -378,6 +378,20 @@ export function createPermissionsWindow(
 }
 
 /**
+ * Brings the popover back to the foreground as the active app. Used after a
+ * scan-all sweep, which activates each scanned app in turn and then restores
+ * whichever app was frontmost before the sweep — leaving What Can't I Press in the
+ * background. On macOS the app is an LSUIElement accessory (no Dock icon), so
+ * pulling it in front of the app the sweep restored needs `app.focus({ steal })`;
+ * `win.focus()` alone would not steal foreground from a regular app.
+ */
+export function activatePopover(win: BrowserWindow): void {
+  if (!win.isVisible()) win.show()
+  if (process.platform === 'darwin') app.focus({ steal: true })
+  win.focus()
+}
+
+/**
  * Reapplies the floating/always-on-top state from `pinned` and `scanning`. While
  * either is active the popover floats above other apps and does not hide on blur.
  */

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -260,6 +260,21 @@ let seededReaderCollapse = false
 let accessibilityGranted: boolean | null = null
 /** Whether the most recent scan was a scan-all sweep (vs frontmost-only). */
 let lastScanAll = false
+/**
+ * Timestamp (ms) when the last scan finished. The window `focus` handler uses it
+ * to skip its default scan-button focus for a short grace period after a scan, so
+ * the post-scan focus set by `runScan` (the filter input, or the permission
+ * banner's Grant access) survives a scan-all sweep re-activating the app a moment
+ * later. Robust to either focus-event ordering; see `runScan`.
+ */
+let lastScanEndedAt = 0
+/**
+ * Grace window after a scan during which the window-focus handler defers to
+ * `runScan`'s post-scan focus instead of focusing the scan button. Far longer than
+ * the native focus-event latency from re-activating the app, yet far shorter than
+ * any human hide-then-reopen, so "reopen lands on the scan button" is preserved.
+ */
+const POST_SCAN_FOCUS_GRACE_MS = 1000
 
 function escapeHtml(value: string): string {
   return value
@@ -882,6 +897,9 @@ function renderAppSection(
 
 /** Whether the accessibility banner was dismissed for the current launch only. */
 let bannerDismissedThisLaunch = false
+/** Shown-state currently reflected in the banner DOM, so a redundant re-render can
+ *  be skipped. `null` until the first render. */
+let renderedBannerShown: boolean | null = null
 
 /**
  * Accessibility banner. Driven by the live Accessibility grant: shown on macOS
@@ -890,13 +908,17 @@ let bannerDismissedThisLaunch = false
  * install (and whenever access is later revoked) and never lingers once access is
  * granted. Dismissal lasts only for the current launch — held in memory, never
  * persisted — so the banner reappears next launch if access is still missing (and
- * so a stale "dismissed" flag can no longer survive an uninstall/reinstall). It is
- * re-rendered only on discrete events (launch, window focus, after a scan), never
- * on filter keystrokes, so it does not flicker as results re-render.
+ * so a stale "dismissed" flag can no longer survive an uninstall/reinstall).
+ *
+ * The DOM is rebuilt only when the shown state actually changes, so a redundant
+ * re-render (this runs on every window focus, via refreshAccessibilityBanner) does
+ * not flicker the banner or discard focus on its Grant access button.
  */
 function renderPermissionBanner(): void {
   const show =
     readerPlatform === 'darwin' && accessibilityGranted === false && !bannerDismissedThisLaunch
+  if (show === renderedBannerShown) return
+  renderedBannerShown = show
   if (!show) {
     bannerEl.innerHTML = ''
     return
@@ -931,6 +953,7 @@ function renderPermissionBanner(): void {
   const dismiss = document.getElementById('banner-dismiss') as HTMLButtonElement
   dismiss.addEventListener('click', () => {
     bannerDismissedThisLaunch = true
+    renderedBannerShown = false
     bannerEl.innerHTML = ''
     scanButton.focus()
   })
@@ -1329,7 +1352,23 @@ async function runScan(scanAllApps: boolean): Promise<void> {
     } else {
       statusEl.textContent = ''
     }
+    // Return focus to the app now that results are shown: the filter input, or the
+    // permission banner's Grant access when access is missing. Record the time so
+    // the window `focus` handler defers to this if a scan-all sweep re-activates
+    // the app a moment later (main brings the popover back to the foreground).
+    lastScanEndedAt = Date.now()
+    focusAfterScan()
   }
+}
+
+/**
+ * Moves focus to where the user's next action is after a scan: the permission
+ * banner's Grant access button when access is missing (the banner, hence `#grant`,
+ * is present), otherwise the filter input.
+ */
+function focusAfterScan(): void {
+  const grant = document.getElementById('grant') as HTMLButtonElement | null
+  ;(grant ?? searchInput).focus()
 }
 
 window.shortcutApi.onScanProgress((progress) => {
@@ -1716,7 +1755,12 @@ content.addEventListener('click', (event) => {
 // re-probe Accessibility so the banner reflects a grant made in System Settings
 // while the popover was hidden.
 window.addEventListener('focus', () => {
-  scanButton.focus()
+  // A scan-all sweep hands the OS foreground to each scanned app and back, then
+  // main re-activates the popover — firing this focus event a moment after the
+  // scan finished. Within the grace window keep the post-scan focus set by
+  // `runScan` (filter input / Grant access) instead of pulling focus to the scan
+  // button; outside it, opening/reopening the popover lands on the scan button.
+  if (Date.now() - lastScanEndedAt > POST_SCAN_FOCUS_GRACE_MS) scanButton.focus()
   void refreshAccessibilityBanner()
 })
 scanButton.focus()


### PR DESCRIPTION
## Describe your proposed changes

After both **Scan last focused app** and **Scan all open apps**, What Can't I Press now returns to the foreground with the **Filter by combo, app, or action** input (`#search`) focused. When the macOS Accessibility banner is showing, focus lands on its **Grant access** button (`#grant`) instead.

Root causes addressed:
- **Scan all open apps** — the sweep activates each app in turn and restores whichever app was frontmost before it (e.g. TextEdit), leaving the popover in the background.
- **Scan last focused app** — OS focus stayed on the popover, but DOM focus fell to `<body>` after the scan button was disabled.

Changes:
- `src/main/window.ts` — new `activatePopover(win)`: show if hidden, `app.focus({ steal: true })` on macOS (required for the `LSUIElement` accessory app to pull ahead of another app), then `win.focus()`.
- `src/main/ipc.ts` — re-activate the popover in the scan handler's `finally` for the scan-all sweep.
- `src/renderer/src/main.ts` — focus the filter input (or `#grant`) after a scan; add a 1000 ms grace window so the `window` focus handler stops stealing focus back to the scan button; make the permission banner render idempotent so a redundant re-render no longer discards focus on the Grant access button.
- Version bump to 1.3.1.

Verification:
- `npm run typecheck` and `npm run build` pass.
- Offscreen Electron renderer harness (mocked `shortcutApi`, CSP-stripped built HTML): 8/8 focus checks pass — init → scan button; window focus outside grace → scan button; granted scan and granted scan-all → filter input; late focus within grace keeps the filter input; denied scan → Grant access; late focus within grace keeps Grant access.
- The OS-level scan-all foreground return (`app.focus({ steal: true })`) is not exercisable by the renderer harness and needs a final on-device confirmation on macOS.

## Link to the Issue proposing these changes

N/A — no separate Issue was filed for this change.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes