### PR TITLE
🤖 Recolor the Windows tray icon for light/dark taskbars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/main/icon.ts
+++ b/src/main/icon.ts
@@ -2,9 +2,11 @@ import { nativeImage, type NativeImage } from 'electron'
 
 /**
  * Menu-bar (tray) icon: a circular target glyph.
- * Pre-rasterized from the source PNG to black-on-transparent RGBA PNGs so it can
- * serve as a macOS template image (macOS recolors it for light/dark menu bars).
- * Two representations are embedded for crisp rendering at @1x (16px) and @2x (32px).
+ * Pre-rasterized from the source PNG to RGBA PNGs. The black-on-transparent pair
+ * serves as a macOS template image (macOS recolors it for light/dark menu bars)
+ * and as the Windows icon for a light taskbar; a white-on-transparent pair is the
+ * Windows icon for a dark taskbar, since Windows does not recolor tray icons.
+ * Each color has @1x (16px) and @2x (32px) representations for crisp rendering.
  */
 const KEYBOARD_PNG_16 =
   'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABS0lEQVQ4y5XTsUpcURAG4O+uQrQy24SIAVcWsUifFJJHyDvExwiWwSdwLdVX0NoilSBI8gAJxFR3CQnYWCiuq8X9rx51hTgwnMM5//nPzPwzNFY9WFvrxkubegLrRdZFbKHGdbzGIHcw25JU6GCMPbzGCl5iF4cBrmINZ/iKHt7hvBMC+Iv32b/BlxBfYSOk//ARv3FepKOHC3zDED+L8Fs/DsFJImnTAZsBzeAg+xEu46OCZC77QUlQYwfLxeNx8fu4IOkHW0v+XcynYKshvH4gU5Uz+BDsPLodz7dq0uEwYfX/I4WlSFyXBINczqVQTxXxBxYmFbEXaU4i1bHHMh4k0tP4rYzTWfcC/JWm6eNTfFnT6t+DOWrr0dF0WivlPl7lh3VNp03hs6bz3mIbf0LYKnPPesmvHKah+8M0UZGqSKe1SeM87W5+3AAgx265gbl7oAAAAABJRU5ErkJggg=='
@@ -12,16 +14,36 @@ const KEYBOARD_PNG_16 =
 const KEYBOARD_PNG_32 =
   'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADcElEQVRYw7WXPU+UQRDHf3dAwsEZNNFELIyxhgQKwU4jsVAxITkSLfQbXH+h0a9gQQFYaGsiFMYY7bRBCjxIBF/QCkjE0GA45fXusdiZe+aWvTeikzzZfWZ2d/47Mzuzm6BxSgAt0j+sMqZV2iIQNbpoLX5kFPtKTwIpkf8GfgXAWCCJEKgQgCRQkn4bcCD9DuAmMAz0Ad1AWmTbwAawALwEXgE7BkhJPruxmjs/YXhtQA5Yl4mNfOvAmMxVOlXP8urfYaAAvJYdfw4oOATWgCVgGVgVnj/uK3AJeCj/j2oB0AB6UWNns0AW6DHmB+gEekU2V2N+ERc7QRBJaQfEAhGwL+2KWMOnFNAe4I8AH41Stc4DT1fQBX3Argdg3oy7DkwBeXHDqvSngCEzblzm7hKfhgHP2mVKGMFKFfPlgRnqB+AzYMLEipV9Iw7MChcoojEz+BOQMe6wfjyQ1n4HuKMWecrHcYGq/JxvBUWSovKoZYR/37gjFOmhE7In/UkTE/aIdljdiiRjBs0Z60xXMWc9EOoOpVkjH7VWUABPzICs8K7Jf6kJ5dZVkQnMrJE9VQBJ4hzfL20ReCf9u4bXLGk6vyPtW7NOn7Tl+tKFy+UR7lh1Cj/v7eY4FsjLWmncsY2An0hC0oTQSZz/t3HVrR04fYyd+3QGF+AF4oqZFl4ZgK1OtnwmGlBQj9Qiuia2rwB2BKG6Iy28zX8AYBOXDUNWLgPYAn5Ivxu4IH1NwSWaJ52jMXAROCf9DcQdSeJjuChtC3BV+nqOkzRPSW+NK8T1ZkHaijwwSmXZxSxw3ET03Kzz3sgzFoAGRgeVqXhE+JPyv9cgiEPiKqrmv2Xk68gJMLrLVsiZgcvEJdUqLtFYMdJvHvhi/sc8nRVIQuVYlU8Yd9T6poF7HK2iuqlgOcYEyGXiTKYXk3Ezbgh4DHzAZc01whcSjal945IbImsjQApAi4aaOcJdr0YCc9qNPy1lPLPr98bs/IgF1Ce1zDwnAHuJ6wW4xNUjsllvzp5xR4E4GVW9lJ4XEFlgEHe1DkX6qvh0SdwQOiHfcVV2EPdgue3pOkKh3N+Ki9xmHyY5ApdPX0e1p1mSuIBoDU8RP836gbPGnAVcKl8kfpr9EVmLrKVrFusBCCEOPU67cHEQ4QrXVsBydV/JzZTb//I8/wtAcL/u4g42NwAAAABJRU5ErkJggg=='
 
+const KEYBOARD_WHITE_PNG_16 =
+  'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABUUlEQVQ4EaXTOy9EQRjG8T0uiZrQEoVrsRIUOglhxaWXKGhEq/QZxDfYrC8h0ShQkEiEhuxq1OsWoSBxGf9nMu8cxTkhPMkv7zlzdt6dnTNbKPwzSdZ859wQ4zMYDM8vqLtJkpyH+1hiAyZNMTqODqzgAVUo/WhFGdeo06xCTUODRVhWuejEcNBFXcYblA2b2WQX1Ak84QOzWEcflBqO8ArN6UYaOhZ9X+eWqJvhOqtsM6iVKEV1aAht5qj3OMBCGMsqYwzuQZ/VnNhAu62dbkcP8tLLA23yJfwbshVoQnwjuvkhzp5bA337AG6gDcuLXmsdtuL4E3YYbMMkjpGXKx7MQ5/VnDTsahkveEYFVXxCqWELj3iHDpSP/QTdnKAlOKSWMBJMU8/QjEbcwef7QTplZA2j0DHVUdZua3N1oLRsje/jFj6ZO88Sf/1nskZ/rl9EgcKquzd0tgAAAABJRU5ErkJggg=='
+
+const KEYBOARD_WHITE_PNG_32 =
+  'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADe0lEQVRYCeWXzUuUURTGZyRXpWIfqBEtrPwIWxSV9AFBH5ZtomXUolXLgtAoyij8CxSirGVrFaLIwtpERR+7wopqExqGmWWQFMb0e97OGa4z7zDMjKt64Jlz3nPPPfe8986ccyeR+N+RLGQDUqnUYvxb4Ua4Bi6BivEZvoPP4JNkMvkFOX9g4SbYAz/AfJCPfJuLyoCJVfASvALr4Vk4BePwC6MYh68YNbcSnoD9cENmUllHgNMRnK6bo7ZS2+6YRrkP78IR+AkqxjK4Du6Gu2AFdLxBabSHGxzPAR+IlSTQAkdhiO88XIYNsZMCIz7NsA9qToifPBwPXCM1bgfKGdFbbg+cX6FvIftvBKlD36tnuAIKo/AxHMJnXAb8BhAHpRu0E+sZn3FDrGSizi0OwxgvwI9xg2YbQ56C3XDWbKHoil3UjXg2Qr2loC3Lt2DkmOdjgPEZ81Hs3MfIYK85SlxTYsg9UMkUg26LcTWY3OsvPEfiUA39yzeNHmWK7IC/YTHosAT0c1ZMQcdUPWdxc2qPhv9+DJqthsfxwF6oqrk1FmswmNzuCZS5gtwc6HdMl2MUIBgrRNVcX2womLjJ9TCBVWZMIV+avs0dS5Bbba4Kl2IL6iMRwgSWmm0WOWn6cpOlCK8VEwRRbCFdXcMEPDs5uJ5VqDRYIOJipeOGCXgLXcACqu2CKlypGLMAat2KLah9RwgTeGs2ZbfW9IcmSxGPbHIL0t/8vQcME9BlwrHPFH1z1fGKhfrCbZus/uF46kpa8htVIVKREFQ06jWIVCEqFucsRgMBvBCp2KULUXoH6FJTOPdrAlA/Px1piUSVyWLEDhbT9+kk9DvCgK2VHQ9nZerNSA1EjaQYhJ1whAA/LIhi++UkOwFZcOgy51AooFqsWq0fUzjuulp1J2yD3ld8TP3kTPyqgRWnhfC1zzLpR6MEa+FRqFvPTXjLdNlqPRT6RRhigoeVPp5T4rQfZl40db3Sgs05J9oAPjpGtV/fdtQ0+jLne2HItOtaJugapTNbBI/BQ4S6hxyGL6DKqyqdmo5qRxvcCSuh4wHKalgHvRT7WLZkgTKo1qydqIC6oumKHQftVOZuuZ+u8udhOdRF9zAME8tePJeFibrp9kD96cgH+ci3KVe80O6lMbTl1AmqLtYK1c+1reqgOoJJqFL+HM7/XzOC/rv4A2gPQik+iuFYAAAAAElFTkSuQmCC'
+
+/** Builds a NativeImage from base64-encoded @1x and @2x PNG representations. */
+function buildImage(png16: string, png32: string): NativeImage {
+  const image = nativeImage.createFromDataURL(`data:image/png;base64,${png16}`)
+  image.addRepresentation({ scaleFactor: 2, dataURL: `data:image/png;base64,${png32}` })
+  return image
+}
+
 /**
- * Builds the tray icon as a template image so macOS can recolor it for
+ * macOS menu-bar icon: a template image so macOS recolors the black glyph for
  * light/dark menu bars, with a base @1x representation and a crisp @2x variant.
  */
 export function createTrayIcon(): NativeImage {
-  const image = nativeImage.createFromDataURL(`data:image/png;base64,${KEYBOARD_PNG_16}`)
-  image.addRepresentation({
-    scaleFactor: 2,
-    dataURL: `data:image/png;base64,${KEYBOARD_PNG_32}`
-  })
+  const image = buildImage(KEYBOARD_PNG_16, KEYBOARD_PNG_32)
   image.setTemplateImage(true)
   return image
+}
+
+/**
+ * Windows tray icon. Windows has no template-image recoloring, so pick an
+ * explicitly-colored glyph for contrast: white for a dark taskbar, black for a
+ * light one.
+ */
+export function createWindowsTrayIcon(darkTaskbar: boolean): NativeImage {
+  return darkTaskbar
+    ? buildImage(KEYBOARD_WHITE_PNG_16, KEYBOARD_WHITE_PNG_32)
+    : buildImage(KEYBOARD_PNG_16, KEYBOARD_PNG_32)
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,9 @@
-import { app, Menu, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { app, Menu, nativeTheme, Tray, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { existsSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { IPC, type MenuCommand } from '@shared/ipc'
-import { createTrayIcon } from './icon'
+import { createTrayIcon, createWindowsTrayIcon } from './icon'
+import { isTaskbarDark } from './theme-win'
 import {
   createAboutWindow,
   createPermissionsWindow,
@@ -44,6 +45,32 @@ function showPopover(): void {
   positionPopover(popover, tray)
   popover.show()
   popover.focus()
+  // Backstop: correct the Windows tray icon color in case a taskbar theme change
+  // did not reach us via nativeTheme 'updated' (no-op on other platforms).
+  void refreshWindowsTrayIcon()
+}
+
+// Fallback poll interval for the Windows taskbar theme, covering the case where
+// nativeTheme 'updated' does not fire for a taskbar-only mode switch.
+const TRAY_THEME_POLL_MS = 5000
+let lastTaskbarDark: boolean | null = null
+
+/**
+ * Windows only: re-reads whether the taskbar is dark and swaps the tray icon to
+ * the contrasting glyph (white on a dark taskbar, black on a light one). No-op on
+ * macOS, where the template image recolors itself, and only touches the image when
+ * the taskbar theme actually changed.
+ */
+async function refreshWindowsTrayIcon(): Promise<void> {
+  if (process.platform !== 'win32' || !tray) return
+  try {
+    const dark = await isTaskbarDark()
+    if (dark === lastTaskbarDark) return
+    lastTaskbarDark = dark
+    tray.setImage(createWindowsTrayIcon(dark))
+  } catch (err) {
+    log(`Tray icon refresh failed: ${describeError(err)}`)
+  }
 }
 
 async function togglePopover(): Promise<void> {
@@ -194,7 +221,9 @@ app.whenReady().then(async () => {
   // item that was created yet not shown (zero width / menu-bar overflow) can be
   // told apart from one that threw.
   try {
-    tray = new Tray(createTrayIcon())
+    tray = new Tray(
+      process.platform === 'win32' ? createWindowsTrayIcon(false) : createTrayIcon()
+    )
     tray.setToolTip("What Can't I Press")
     tray.on('click', (event) => {
       // Control-click on macOS is a secondary click: show the context menu, the
@@ -206,6 +235,15 @@ app.whenReady().then(async () => {
       void togglePopover()
     })
     tray.on('right-click', showTrayMenu)
+    if (process.platform === 'win32') {
+      // Windows draws the tray icon as supplied (no template recoloring), so pick
+      // the contrasting glyph now and again whenever the taskbar theme changes.
+      // The interval is a fallback for taskbar-only switches that may not emit a
+      // nativeTheme 'updated' event.
+      void refreshWindowsTrayIcon()
+      nativeTheme.on('updated', () => void refreshWindowsTrayIcon())
+      setInterval(() => void refreshWindowsTrayIcon(), TRAY_THEME_POLL_MS)
+    }
     const b = tray.getBounds()
     log(`Tray created (bounds x=${b.x} y=${b.y} w=${b.width} h=${b.height})`)
   } catch (err) {

--- a/src/main/theme-win.ts
+++ b/src/main/theme-win.ts
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process'
+
+// The taskbar (and therefore the tray/notification area) follows Windows' "system"
+// theme, stored as SystemUsesLightTheme. This is separate from the "app" theme
+// (AppsUseLightTheme) that Electron's nativeTheme.shouldUseDarkColors reports, so
+// the registry value is read directly. 0 = dark taskbar, 1 (or absent) = light.
+const PERSONALIZE_KEY =
+  'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize'
+
+/**
+ * Resolves whether the Windows taskbar is in dark mode by reading the
+ * SystemUsesLightTheme registry value. Resolves `false` (treat the taskbar as
+ * light) on any error, if the value is missing, or off Windows — matching the
+ * Windows default when the key is absent.
+ */
+export function isTaskbarDark(): Promise<boolean> {
+  if (process.platform !== 'win32') return Promise.resolve(false)
+  return new Promise((resolve) => {
+    execFile(
+      'reg',
+      ['query', PERSONALIZE_KEY, '/v', 'SystemUsesLightTheme'],
+      { timeout: 2000, windowsHide: true },
+      (err, stdout) => {
+        if (err) {
+          resolve(false)
+          return
+        }
+        const match = /SystemUsesLightTheme\s+REG_DWORD\s+0x([0-9a-fA-F]+)/.exec(stdout)
+        resolve(match ? parseInt(match[1], 16) === 0 : false)
+      }
+    )
+  })
+}


### PR DESCRIPTION
## Describe your proposed changes

On Windows the menu-bar (tray) icon is drawn exactly as supplied — Windows does no template-image recoloring — so the black glyph nearly disappeared against a dark taskbar. This adds a white glyph variant and selects the contrasting icon based on the taskbar's own light/dark setting.

- **New `src/main/theme-win.ts`**: reads the Windows `SystemUsesLightTheme` registry value (the taskbar/system theme, which is separate from the app theme that `nativeTheme.shouldUseDarkColors` reports). Falls back to light on any error or off Windows.
- **`src/main/icon.ts`**: adds a white 16px/32px glyph and `createWindowsTrayIcon(darkTaskbar)` — white on a dark taskbar, black on a light one.
- **`src/main/index.ts`**: on Windows the tray starts with the contrasting glyph and refreshes on three triggers — `nativeTheme` `updated`, every popover open, and a 5-second fallback poll — swapping the image only when the taskbar theme actually changed.

macOS is unchanged: it keeps its self-recoloring template icon.

Also bumps the version to 1.3.2.

## Link to the Issue proposing these changes

None — requested directly; no Issue was filed.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes

### Testing notes

- Verified on macOS: `npm run typecheck` and `npm run build` pass; registry-output parsing checked against `0x0`/`0x1`/missing; all four embedded PNGs decode at 16px/32px.
- Not verified: the Windows runtime path (registry read + live icon swap on a taskbar light/dark toggle) has not been exercised on a real Windows machine.