### PR TITLE
🤖 Run release workflow actions on Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,17 +39,17 @@ jobs:
       HAS_MAC_CERT: ${{ secrets.MAC_SELFSIGN_P12_BASE64 != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
 
       - name: Set up .NET SDK (Windows helper)
         if: matrix.platform == 'win'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 8.0.x
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload macOS installers
         if: matrix.platform == 'mac'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installers-mac
           path: |
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload Windows installers
         if: matrix.platform == 'win'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installers-win
           path: |
@@ -154,7 +154,7 @@ jobs:
       contents: write
     steps:
       - name: Download all installers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: installers-*


### PR DESCRIPTION
## Describe your proposed changes

Clears the GitHub Actions runner warning — *"Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24…"* — on the Release workflow by bumping every `actions/*` pinned at `@v4` (which declare `runs.using: node20`) to their current majors that natively declare `node24`:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/setup-dotnet` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 (both upload steps) |
| `actions/download-artifact` | v4 | v8 |

Only `.github/workflows/release.yml` changes — 6 `uses:` lines. Every input the workflow relies on (`node-version`, `cache`, `dotnet-version`, `name`/`path`/`if-no-files-found`, `pattern`/`merge-multiple`) still exists in the target majors. `node-version: 22` and `dotnet-version: 8.0.x` are unchanged — those pin the build runtimes, not the action host.

The runner warning named only 3 of the 5 actions because the observed run did not execute `setup-dotnet` (Windows-only leg) or `download-artifact` (tag-gated publish job); both are still `@v4` and would warn on a real tag/Windows run, so all five are bumped for a complete fix.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Link to the Issue proposing these changes

N/A — no separate Issue filed. Low-risk maintenance change that clears a runner deprecation warning.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes

Validation performed: `release.yml` parses as valid YAML and all `uses:` lines resolve to Node 24 majors. Full runner verification (annotation cleared) requires a `workflow_dispatch` run; the `download-artifact` leg only exercises on a real `v*.*.*` tag push.