### PR TITLE
🤖 Detect Windows app shortcuts via curated menu data + live menu expansion

### DIFF
--- a/native/windows/ShortcutHelper.cs
+++ b/native/windows/ShortcutHelper.cs
@@ -19,6 +19,11 @@ internal static class Program
     private const int SW_RESTORE = 9;
     private const int MaxMenuItems = 2000;
 
+    // Best-effort menu expansion (Pass 2 of ReadMenu) opens each top-level menu
+    // in turn; cap the total time so a slow or unresponsive app cannot hang the
+    // reader. Pass 1's statically-readable accelerators are already collected.
+    private static readonly TimeSpan MenuBudget = TimeSpan.FromSeconds(6);
+
     [DllImport("user32.dll")]
     private static extern IntPtr GetForegroundWindow();
 
@@ -73,6 +78,30 @@ internal static class Program
     private static int ParsePid(string[] args)
         => args.Length > 1 && int.TryParse(args[1], out var pid) ? pid : 0;
 
+    /// <summary>
+    /// Resolves a stable, human-friendly app name (e.g. "Notepad") from the
+    /// executable's version info, falling back to the process name. Preferred
+    /// over the window title, which changes with the open document and does not
+    /// match curated app identities. Mirrors the macOS helper's app name.
+    /// </summary>
+    private static string FriendlyName(Process process)
+    {
+        try
+        {
+            var description = process.MainModule?.FileVersionInfo.FileDescription;
+            if (!string.IsNullOrWhiteSpace(description))
+            {
+                return description!.Trim();
+            }
+        }
+        catch
+        {
+            // MainModule is inaccessible for elevated / other-user processes.
+        }
+
+        return process.ProcessName;
+    }
+
     private static void Emit(object value)
         => Console.WriteLine(JsonSerializer.Serialize(value));
 
@@ -94,7 +123,7 @@ internal static class Program
                     continue;
                 }
 
-                apps.Add(new { id = process.ProcessName, name = title, pid = process.Id });
+                apps.Add(new { id = process.ProcessName, name = FriendlyName(process), pid = process.Id });
             }
             catch
             {
@@ -122,11 +151,10 @@ internal static class Program
         try
         {
             var process = Process.GetProcessById((int)pid);
-            var title = process.MainWindowTitle;
             return new
             {
                 id = process.ProcessName,
-                name = string.IsNullOrWhiteSpace(title) ? process.ProcessName : title,
+                name = FriendlyName(process),
                 pid = (int)pid
             };
         }
@@ -168,61 +196,185 @@ internal static class Program
             return result;
         }
 
-        var cache = new CacheRequest();
-        cache.Add(AutomationElement.NameProperty);
-        cache.Add(AutomationElement.AcceleratorKeyProperty);
+        var seen = new HashSet<string>();
+        var stopwatch = Stopwatch.StartNew();
+        var menuItemCondition = new PropertyCondition(
+            AutomationElement.ControlTypeProperty, ControlType.MenuItem);
+
+        // Whether there is still room and time to keep reading.
+        bool WithinBudget() => result.Count < MaxMenuItems && stopwatch.Elapsed <= MenuBudget;
+
+        void Add(string? title, string? accelerator)
+        {
+            if (string.IsNullOrWhiteSpace(accelerator))
+            {
+                return;
+            }
+
+            var label = title ?? string.Empty;
+            if (seen.Add(label + "\u0000" + accelerator))
+            {
+                result.Add(new { title = label, accelerator });
+            }
+        }
+
+        // Reads every menu item under an element that already carries an
+        // accelerator. Used for both the static pass and each expanded dropdown.
+        void ReadItemsUnder(AutomationElement root)
+        {
+            AutomationElementCollection items;
+            try
+            {
+                items = root.FindAll(TreeScope.Descendants, menuItemCondition);
+            }
+            catch
+            {
+                return;
+            }
+
+            foreach (AutomationElement item in items)
+            {
+                if (!WithinBudget())
+                {
+                    return;
+                }
+
+                try
+                {
+                    Add(
+                        item.GetCurrentPropertyValue(AutomationElement.NameProperty) as string,
+                        item.GetCurrentPropertyValue(AutomationElement.AcceleratorKeyProperty) as string);
+                }
+                catch
+                {
+                    // Element went stale as its menu closed; skip it.
+                }
+            }
+        }
 
         // Menu bars are far cheaper to scan than an entire window subtree.
-        var roots = new List<AutomationElement>();
+        var bars = new List<AutomationElement>();
         var menuBars = window.FindAll(
             TreeScope.Descendants,
             new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.MenuBar));
         foreach (AutomationElement bar in menuBars)
         {
-            roots.Add(bar);
+            bars.Add(bar);
         }
 
-        if (roots.Count == 0)
+        if (bars.Count == 0)
         {
-            roots.Add(window);
+            bars.Add(window);
         }
 
-        var seen = new HashSet<string>();
-        var menuItemCondition = new PropertyCondition(
-            AutomationElement.ControlTypeProperty, ControlType.MenuItem);
-
-        foreach (var root in roots)
+        // Pass 1 (cheap, non-disruptive): collect accelerators already present in
+        // the tree. Covers apps that expose them statically (e.g. WinForms/WPF
+        // menus). Classic Win32 menus expose only top-level names here.
+        foreach (var bar in bars)
         {
-            AutomationElementCollection items;
-            using (cache.Activate())
+            ReadItemsUnder(bar);
+            if (!WithinBudget())
             {
-                items = root.FindAll(TreeScope.Descendants, menuItemCondition);
+                return result;
+            }
+        }
+
+        // Pass 2 (best-effort, disruptive): classic Win32 dropdown items are
+        // absent from the UI Automation tree until their menu is opened. Expand
+        // each top-level menu-bar item so its items materialize, read them, then
+        // collapse. Guarded so any failure degrades to Pass 1's result.
+        foreach (var bar in bars)
+        {
+            AutomationElementCollection tops;
+            try
+            {
+                tops = bar.FindAll(TreeScope.Children, menuItemCondition);
+            }
+            catch
+            {
+                continue;
             }
 
-            foreach (AutomationElement item in items)
+            foreach (AutomationElement top in tops)
             {
-                if (result.Count >= MaxMenuItems)
+                if (!WithinBudget())
                 {
                     return result;
                 }
 
-                var accelerator = item.GetCachedPropertyValue(
-                    AutomationElement.AcceleratorKeyProperty) as string;
-                if (string.IsNullOrWhiteSpace(accelerator))
-                {
-                    continue;
-                }
-
-                var title = item.GetCachedPropertyValue(
-                    AutomationElement.NameProperty) as string ?? string.Empty;
-
-                if (seen.Add(title + "\u0000" + accelerator))
-                {
-                    result.Add(new { title, accelerator });
-                }
+                ExpandAndReadDropdown(top, ReadItemsUnder);
             }
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Expands a top-level menu item via <see cref="ExpandCollapsePattern"/> so
+    /// its (lazily created) dropdown items appear, reads their accelerators, then
+    /// collapses it. Win32 dropdowns open as a separate popup menu parented to the
+    /// desktop root rather than under the menu item, so both locations are read.
+    /// No-op for items without the pattern (e.g. leaf items, modern apps).
+    /// </summary>
+    private static void ExpandAndReadDropdown(
+        AutomationElement top,
+        Action<AutomationElement> readItemsUnder)
+    {
+        ExpandCollapsePattern? pattern = null;
+        try
+        {
+            if (top.TryGetCurrentPattern(ExpandCollapsePattern.Pattern, out var raw))
+            {
+                pattern = (ExpandCollapsePattern)raw;
+            }
+        }
+        catch
+        {
+            pattern = null;
+        }
+
+        if (pattern is null)
+        {
+            return;
+        }
+
+        try
+        {
+            pattern.Expand();
+        }
+        catch
+        {
+            return;
+        }
+
+        try
+        {
+            // Give the dropdown a moment to render its items.
+            Thread.Sleep(60);
+            readItemsUnder(top);
+
+            var popup = AutomationElement.RootElement.FindFirst(
+                TreeScope.Children,
+                new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Menu));
+            if (popup is not null)
+            {
+                readItemsUnder(popup);
+            }
+        }
+        catch
+        {
+            // Reading a transient popup can race its teardown; ignore.
+        }
+        finally
+        {
+            try
+            {
+                pattern.Collapse();
+            }
+            catch
+            {
+                // Leave nothing open if collapse fails; best-effort.
+            }
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/main/core/curated-data.ts
+++ b/src/main/core/curated-data.ts
@@ -15,15 +15,32 @@ export interface CuratedApp {
   processNames?: string[]
   /** Lower-cased substrings matched against a running app's name or id. */
   aliases?: string[]
-  shortcuts: CuratedShortcut[]
+  /**
+   * Global hotkeys reserved system-wide while the app runs (the `global-app`
+   * segment), independent of focus. Optional so an entry can supply only
+   * `menuShortcuts`.
+   */
+  shortcuts?: CuratedShortcut[]
+  /**
+   * In-app shortcuts reserved only while the app is frontmost (the
+   * `focused-menu` segment). These fill the gap on platforms whose menus cannot
+   * be enumerated live: on Windows, UI Automation exposes no accelerator table
+   * for a background app (classic menu items are absent from the tree until the
+   * menu is opened, and modern apps have no classic menu). A live scan that does
+   * recover a value supersedes the curated default here (aggregation prefers
+   * `detected` over `curated`).
+   */
+  menuShortcuts?: CuratedShortcut[]
 }
 
 /**
- * Curated default global hotkeys for common third-party apps. These occupy the
- * "works when the app is not focused" segment, which no OS API exposes for other
- * processes. Values are the apps' shipped defaults and may be remapped by the
- * user; the UI surfaces that caveat. Identity is matched by bundle id / process
- * name first, with name aliases as a fallback.
+ * Curated default hotkeys for common apps. `shortcuts` occupy the "works when
+ * the app is not focused" (`global-app`) segment, which no OS API exposes for
+ * other processes; `menuShortcuts` occupy the "only while frontmost"
+ * (`focused-menu`) segment, used where menus cannot be enumerated live (Windows).
+ * Values are the apps' shipped defaults and may be remapped by the user; the UI
+ * surfaces that caveat. Identity is matched by bundle id / process name first,
+ * with name aliases as a fallback.
  */
 export const CURATED_APPS: CuratedApp[] = [
   {
@@ -118,5 +135,81 @@ export const CURATED_APPS: CuratedApp[] = [
     processNames: ['snagit32', 'snagiteditor', 'snagit'],
     aliases: ['snagit'],
     shortcuts: [{ modifiers: [], key: 'PrintScreen', description: 'Capture (Snagit global capture)' }]
+  },
+  {
+    platform: 'win32',
+    appName: 'Notepad',
+    processNames: ['notepad'],
+    aliases: ['notepad'],
+    menuShortcuts: [
+      { modifiers: ['control'], key: 'N', description: 'New' },
+      { modifiers: ['control', 'shift'], key: 'N', description: 'New window' },
+      { modifiers: ['control'], key: 'O', description: 'Open' },
+      { modifiers: ['control'], key: 'S', description: 'Save' },
+      { modifiers: ['control', 'shift'], key: 'S', description: 'Save as' },
+      { modifiers: ['control'], key: 'P', description: 'Print' },
+      { modifiers: ['control'], key: 'W', description: 'Close' },
+      { modifiers: ['control'], key: 'Z', description: 'Undo' },
+      { modifiers: ['control'], key: 'Y', description: 'Redo' },
+      { modifiers: ['control'], key: 'X', description: 'Cut' },
+      { modifiers: ['control'], key: 'C', description: 'Copy' },
+      { modifiers: ['control'], key: 'V', description: 'Paste' },
+      { modifiers: ['control'], key: 'A', description: 'Select all' },
+      { modifiers: ['control'], key: 'F', description: 'Find' },
+      { modifiers: ['control'], key: 'H', description: 'Replace' },
+      { modifiers: ['control'], key: 'G', description: 'Go to line' },
+      { modifiers: [], key: 'F5', description: 'Insert date and time' }
+    ]
+  },
+  {
+    platform: 'win32',
+    appName: 'File Explorer',
+    processNames: ['explorer'],
+    aliases: ['file explorer'],
+    menuShortcuts: [
+      { modifiers: ['control'], key: 'N', description: 'Open new window' },
+      { modifiers: ['control'], key: 'W', description: 'Close window' },
+      { modifiers: ['control', 'shift'], key: 'N', description: 'New folder' },
+      { modifiers: ['control'], key: 'F', description: 'Search' },
+      { modifiers: [], key: 'F2', description: 'Rename' },
+      { modifiers: [], key: 'F5', description: 'Refresh' },
+      { modifiers: ['option'], key: 'Return', description: 'Properties' },
+      { modifiers: ['option'], key: 'Up', description: 'Up one level' },
+      { modifiers: ['option'], key: 'Left', description: 'Back' },
+      { modifiers: ['option'], key: 'Right', description: 'Forward' }
+    ]
+  },
+  {
+    platform: 'win32',
+    appName: 'Windows Terminal',
+    processNames: ['windowsterminal'],
+    aliases: ['windows terminal'],
+    menuShortcuts: [
+      { modifiers: ['control', 'shift'], key: 'T', description: 'New tab' },
+      { modifiers: ['control', 'shift'], key: 'W', description: 'Close tab' },
+      { modifiers: ['control', 'shift'], key: 'D', description: 'Duplicate tab' },
+      { modifiers: ['control', 'shift'], key: 'P', description: 'Open the command palette' },
+      { modifiers: ['control', 'shift'], key: 'F', description: 'Find' },
+      { modifiers: ['option', 'shift'], key: 'D', description: 'Split pane' },
+      { modifiers: ['control'], key: ',', description: 'Open settings' }
+    ]
+  },
+  {
+    platform: 'win32',
+    appName: 'Microsoft Edge',
+    processNames: ['msedge'],
+    aliases: ['microsoft edge'],
+    menuShortcuts: [
+      { modifiers: ['control'], key: 'T', description: 'New tab' },
+      { modifiers: ['control'], key: 'W', description: 'Close tab' },
+      { modifiers: ['control', 'shift'], key: 'T', description: 'Reopen closed tab' },
+      { modifiers: ['control'], key: 'N', description: 'New window' },
+      { modifiers: ['control', 'shift'], key: 'N', description: 'New InPrivate window' },
+      { modifiers: ['control'], key: 'L', description: 'Select the address bar' },
+      { modifiers: ['control'], key: 'D', description: 'Add this page to favorites' },
+      { modifiers: ['control'], key: 'F', description: 'Find on page' },
+      { modifiers: ['control'], key: 'R', description: 'Reload' },
+      { modifiers: ['control'], key: 'P', description: 'Print' }
+    ]
   }
 ]

--- a/src/main/core/curated.ts
+++ b/src/main/core/curated.ts
@@ -28,6 +28,7 @@ export function getCuratedShortcuts(apps: RunningApp[], platform: Platform): Raw
 
   for (const entry of CURATED_APPS) {
     if (entry.platform !== platform) continue
+    if (!entry.shortcuts?.length) continue
     const match = findMatch(entry, apps)
     if (!match) continue
 
@@ -39,6 +40,40 @@ export function getCuratedShortcuts(apps: RunningApp[], platform: Platform): Raw
         segment: 'global-app',
         source: 'curated',
         appId: match.id,
+        appName: entry.appName,
+        description: sc.description,
+        enabled: true
+      })
+    }
+  }
+
+  return raws
+}
+
+/**
+ * Returns curated in-app (frontmost-only) shortcuts for a single running app, in
+ * the `focused-menu` segment. This is the fallback for platforms whose menus
+ * cannot be read live for a background app (Windows UI Automation exposes no
+ * accelerator table without opening each menu). Scoped to one app so a
+ * frontmost-only scan surfaces only the focused app's shortcuts. A live-detected
+ * value for the same combo supersedes the curated one during aggregation.
+ */
+export function getCuratedMenuShortcuts(app: RunningApp, platform: Platform): RawShortcut[] {
+  const raws: RawShortcut[] = []
+
+  for (const entry of CURATED_APPS) {
+    if (entry.platform !== platform) continue
+    if (!entry.menuShortcuts?.length) continue
+    if (!findMatch(entry, [app])) continue
+
+    for (const sc of entry.menuShortcuts) {
+      raws.push({
+        key: sc.key,
+        modifiers: sc.modifiers,
+        origin: 'app',
+        segment: 'focused-menu',
+        source: 'curated',
+        appId: app.id,
         appName: entry.appName,
         description: sc.description,
         enabled: true

--- a/src/main/core/scan-runner.ts
+++ b/src/main/core/scan-runner.ts
@@ -2,7 +2,7 @@ import type { ScanOptions, ScanProgress, ScanResult, CoverageGap } from '@shared
 import type { RawShortcut } from '@shared/shortcuts'
 import type { PlatformProvider, RunningApp } from '../providers/types'
 import { aggregate } from './aggregate'
-import { getCuratedShortcuts } from './curated'
+import { getCuratedShortcuts, getCuratedMenuShortcuts } from './curated'
 import { getScreenReaderShortcuts, isScreenReaderApp } from './screen-readers'
 
 /** Simple cooperative cancellation token flipped by the cancel IPC. */
@@ -69,12 +69,16 @@ async function scanFrontmostOnly(
   }
 
   onProgress({ phase: 'apps', current: 1, total: 1, appName: frontmost.name })
+  // Curated in-app defaults are included whether or not the live read yields
+  // anything, so platforms whose menus cannot be read live (Windows) still show
+  // the focused app's shortcuts. A live-detected duplicate supersedes them.
+  const curated = getCuratedMenuShortcuts(frontmost, provider.platform)
   try {
     const raws = await provider.readAppMenuShortcuts(frontmost)
     const gaps = await provider.readCoverageGaps(frontmost)
-    return { raws, appsScanned: 1, gaps, targetName: frontmost.name }
+    return { raws: [...raws, ...curated], appsScanned: 1, gaps, targetName: frontmost.name }
   } catch {
-    return { raws: [], appsScanned: 0, gaps: [], targetName: frontmost.name }
+    return { raws: curated, appsScanned: 1, gaps: [], targetName: frontmost.name }
   }
 }
 
@@ -106,6 +110,10 @@ async function scanAllApps(
       const app = targets[i]
       onProgress({ phase: 'apps', current: i + 1, total, appName: app.name })
 
+      // Curated in-app defaults are added regardless of the live read, so apps
+      // whose menus cannot be enumerated live (Windows) still contribute. A
+      // live-detected duplicate supersedes them during aggregation.
+      raws.push(...getCuratedMenuShortcuts(app, provider.platform))
       try {
         await provider.activateApp(app)
         await delay(ACTIVATION_SETTLE_MS)

--- a/src/main/providers/windows/index.ts
+++ b/src/main/providers/windows/index.ts
@@ -1,10 +1,12 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { app } from 'electron'
 import type { Platform, RawShortcut } from '@shared/shortcuts'
 import type { CoverageGap, PermissionStatus } from '@shared/scan'
 import type { PlatformProvider, RunningApp } from '../types'
+import { log, describeError } from '../../core/logger'
 import { parseAcceleratorString } from './accelerators'
 import { windowsOsShortcuts } from './os-shortcuts'
 
@@ -31,14 +33,22 @@ function helperPath(): string {
 
 /** Invokes the .NET UI Automation helper and parses its JSON output. */
 async function runHelper<T>(args: string[]): Promise<T | null> {
+  const bin = helperPath()
+  // Distinguish a missing binary (packaging/build problem) from a runtime
+  // failure or empty result, which otherwise look identical to the renderer.
+  if (!existsSync(bin)) {
+    log(`windows helper missing at ${bin}`)
+    return null
+  }
   try {
-    const { stdout } = await execFileAsync(helperPath(), args, {
+    const { stdout } = await execFileAsync(bin, args, {
       timeout: 12000,
       maxBuffer: 16 * 1024 * 1024,
       windowsHide: true
     })
     return JSON.parse(stdout) as T
-  } catch {
+  } catch (err) {
+    log(`windows helper failed (${args.join(' ')}): ${describeError(err)}`)
     return null
   }
 }


### PR DESCRIPTION
## Describe your proposed changes

**Problem.** On Windows, both scan buttons fired but no per-app shortcuts were detected (only global hotkeys); macOS was unaffected. Root cause: Windows UI Automation cannot enumerate a background app's menu accelerators — classic Win32 dropdown items are not realized in the UIA tree until the menu is opened, and modern apps (Win11 Notepad/WinUI, ribbon, browsers, Electron) have no classic menu at all. No Windows API exposes a background app's accelerator table the way macOS `AXMenuBar` does.

**Fix (both strategies).**
- **Curated per-app defaults as the reliable base.** Added `menuShortcuts` to the curated dataset for four Windows apps — Notepad, File Explorer, Windows Terminal, Microsoft Edge — emitted into the `focused-menu` segment, grouped by app, carrying a "Built-in guess" badge (`source: 'curated'`). Matched to the running app by process name.
- **Best-effort live scanning where a classic menu exists.** Rewrote `ReadMenu` in the .NET helper as two passes: a static read, then a time-bounded `ExpandCollapsePattern` expansion of top-level menus (budget 6s / 2000 items). Live-detected shortcuts supersede curated ones for the same combo via the existing aggregation merge.
- **Diagnostics.** The Windows provider now logs a missing helper binary and logs helper failures (command + error) instead of swallowing them silently. Helper now reports a friendly app name (FileVersionInfo) rather than the window title.

Version bumped `1.3.1` → `1.4.0`.

**Verification.** `npm run typecheck` and `npm run build` pass. A node/esbuild smoke test confirms curated menu data reaches `result.shortcuts` on both scan modes and that live-detected entries supersede curated ones. The `.cs` helper compiles only on Windows/.NET 8 (covered in CI), so it was not compiled locally, and the live-expansion yield on real classic Win32 apps is unconfirmed without a Windows host (⚠️). An already-installed build will not pick up the helper change until a fresh Windows build ships.

## Link to the Issue proposing these changes

No tracking Issue exists for this change.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes