### PR TITLE
🤖 Add drag-to-move by the popover header (v1.4.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -223,6 +223,16 @@ header {
   border-bottom: 1px solid var(--border);
 }
 
+/* Make the frameless popover draggable by its header (native OS window drag).
+   The interactive buttons opt back out so they stay clickable. */
+#header {
+  -webkit-app-region: drag;
+}
+
+#header button {
+  -webkit-app-region: no-drag;
+}
+
 header h1 {
   font-size: 13px;
   font-weight: 600;


### PR DESCRIPTION
## Describe your proposed changes

Makes the frameless menu-bar popover draggable by its header, so you can click-hold the header and move the window around the screen.

**Implementation** — CSS only, in `src/renderer/src/styles.css`:

```css
#header { -webkit-app-region: drag; }            /* grab-and-move the window */
#header button { -webkit-app-region: no-drag; }  /* Pin/Quit stay clickable */
```

This uses Electron's native frameless window-drag mechanism — no JavaScript, IPC, or main-process change. Non-interactive header content (title/subtitle) stays draggable because `-webkit-app-region` is not inherited and only `no-drag` elements subtract from the header's drag region.

**Behavior**: the dragged position is intentionally not persisted. The existing `showPopover` → `positionPopover` path re-anchors the window to the tray icon on each explicit reveal (tray click, relaunch, macOS activate), matching typical menu-bar apps. While the window stays open (e.g. pinned), it holds wherever it was dragged. Double-clicking the header is inert — the window is non-maximizable/minimizable, so there is no accidental zoom.

Also bumps the version to **1.4.1** (`package.json` + `package-lock.json`).

## Link to the Issue proposing these changes

No separate Issue — this originated from a direct maintainer request.

## Checklist

- [ ] I have tested these changes in Windows
- [ ] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes

Automated validation performed: `npm run typecheck` and `npm run build` pass, and a headless Electron computed-style check confirms `#header` resolves to `-webkit-app-region: drag` while `#pin`/`#quit` resolve to `no-drag`. A manual, on-hardware drag check on macOS and Windows is still recommended before merge.