### PR TITLE
🤖 Bump version to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",


### PR DESCRIPTION
## Describe your proposed changes

**Required.**

Bumps the app version from 1.4.1 to 1.4.2 in `package.json` and `package-lock.json`. This is the release version for the chord-filter keyboard focus-exit work merged in #21 (Shift+Tab+Tab exit gesture and clear-on-exit for the "Press a shortcut to filter" input).

Metadata only, no functional or code changes.

## Link to the Issue proposing these changes

**Required.**

N/A

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes