### PR TITLE
🤖 Replace `nm` with an in-process Mach-O symbol reader on macOS

### DIFF
--- a/src/main/providers/macos/macho.ts
+++ b/src/main/providers/macos/macho.ts
@@ -1,0 +1,209 @@
+import { open, type FileHandle } from 'node:fs/promises'
+
+/**
+ * Minimal, dependency-free Mach-O reader used to answer a single question:
+ * does a binary's symbol table contain a given undefined (imported) symbol?
+ * This replaces shelling out to `nm`, which is a Command Line Tools stub and
+ * pops the "install the command line developer tools" dialog on Macs without
+ * Xcode installed.
+ *
+ * Only the pieces needed for that question are parsed: the fat header (to pick
+ * the host-architecture slice), the Mach-O header, the LC_SYMTAB load command,
+ * and its symbol + string tables. Everything is best-effort — any malformed or
+ * unexpected structure resolves to `false` rather than throwing.
+ */
+
+// Universal ("fat") archive magics. Fat headers are always big-endian on disk.
+const FAT_MAGIC = 0xcafebabe
+const FAT_MAGIC_64 = 0xcafebabf
+
+// Thin Mach-O magics, read big-endian. *_CIGAM means the slice is little-endian
+// (the native byte order for x86_64 and arm64 macOS binaries).
+const MH_MAGIC = 0xfeedface
+const MH_CIGAM = 0xcefaedfe
+const MH_MAGIC_64 = 0xfeedfacf
+const MH_CIGAM_64 = 0xcffaedfe
+
+const LC_SYMTAB = 0x2
+
+// nlist n_type field masks.
+const N_STAB = 0xe0 // debug (STABS) symbol — skip
+const N_TYPE = 0x0e // type bits
+const N_UNDF = 0x00 // undefined
+
+const CPU_TYPE_X86_64 = 0x01000007
+const CPU_TYPE_ARM64 = 0x0100000c
+
+// Sanity caps so a corrupt or hostile binary can never make us allocate wildly.
+const MAX_FAT_ARCHES = 64
+const MAX_LOAD_COMMANDS_BYTES = 2 * 1024 * 1024
+const MAX_SYMTAB_BYTES = 64 * 1024 * 1024
+const MAX_STRTAB_BYTES = 128 * 1024 * 1024
+
+function readU32(buf: Buffer, off: number, le: boolean): number {
+  return le ? buf.readUInt32LE(off) : buf.readUInt32BE(off)
+}
+
+function readU64(buf: Buffer, off: number, le: boolean): bigint {
+  return le ? buf.readBigUInt64LE(off) : buf.readBigUInt64BE(off)
+}
+
+/** Reads exactly `length` bytes at `offset`, throwing on a short read. */
+async function readExact(fh: FileHandle, offset: number, length: number): Promise<Buffer> {
+  const buf = Buffer.allocUnsafe(length)
+  let read = 0
+  while (read < length) {
+    const { bytesRead } = await fh.read(buf, read, length - read, offset + read)
+    if (bytesRead === 0) break
+    read += bytesRead
+  }
+  if (read < length) throw new Error('unexpected end of file')
+  return buf
+}
+
+function hostCpuType(): number {
+  return process.arch === 'arm64' ? CPU_TYPE_ARM64 : CPU_TYPE_X86_64
+}
+
+/**
+ * Picks the file offset of the slice matching the host architecture, falling
+ * back to the first slice when the host arch is absent. Returns -1 on a
+ * malformed fat header.
+ */
+async function selectFatSlice(fh: FileHandle, is64: boolean): Promise<number> {
+  const header = await readExact(fh, 0, 8)
+  const nArch = header.readUInt32BE(4)
+  if (nArch === 0 || nArch > MAX_FAT_ARCHES) return -1
+
+  const archSize = is64 ? 32 : 20
+  const table = await readExact(fh, 8, nArch * archSize)
+  const wanted = hostCpuType()
+
+  let firstOffset = -1
+  for (let i = 0; i < nArch; i++) {
+    const base = i * archSize
+    const cpuType = table.readUInt32BE(base) >>> 0
+    const offset = is64
+      ? Number(table.readBigUInt64BE(base + 8))
+      : table.readUInt32BE(base + 8)
+    if (i === 0) firstOffset = offset
+    if (cpuType === wanted) return offset
+  }
+  return firstOffset
+}
+
+/** True when `strs[start..]` equals `target` and is NUL-terminated (or ends the table). */
+function symbolNameMatches(strs: Buffer, start: number, target: Buffer): boolean {
+  const end = start + target.length
+  if (end > strs.length) return false
+  if (end < strs.length && strs[end] !== 0) return false
+  return strs.compare(target, 0, target.length, start, end) === 0
+}
+
+/**
+ * Scans one Mach-O image (at `sliceOffset` within the file) for an undefined
+ * external symbol named `symbol`. Mirrors `nm -u`: undefined entries only,
+ * excluding common symbols (N_UNDF with a non-zero value) and debug symbols.
+ */
+async function machoImportsSymbol(
+  fh: FileHandle,
+  sliceOffset: number,
+  symbol: string
+): Promise<boolean> {
+  const magicBE = (await readExact(fh, sliceOffset, 4)).readUInt32BE(0)
+
+  let le: boolean
+  let is64: boolean
+  if (magicBE === MH_MAGIC_64) {
+    le = false
+    is64 = true
+  } else if (magicBE === MH_CIGAM_64) {
+    le = true
+    is64 = true
+  } else if (magicBE === MH_MAGIC) {
+    le = false
+    is64 = false
+  } else if (magicBE === MH_CIGAM) {
+    le = true
+    is64 = false
+  } else {
+    return false
+  }
+
+  const headerSize = is64 ? 32 : 28
+  const header = await readExact(fh, sliceOffset, headerSize)
+  const ncmds = readU32(header, 16, le)
+  const sizeofcmds = readU32(header, 20, le)
+  if (sizeofcmds === 0 || sizeofcmds > MAX_LOAD_COMMANDS_BYTES) return false
+
+  const cmds = await readExact(fh, sliceOffset + headerSize, sizeofcmds)
+
+  let symoff = 0
+  let nsyms = 0
+  let stroff = 0
+  let strsize = 0
+  let found = false
+  let off = 0
+  for (let i = 0; i < ncmds; i++) {
+    if (off + 8 > cmds.length) break
+    const cmd = readU32(cmds, off, le)
+    const cmdsize = readU32(cmds, off + 4, le)
+    if (cmdsize < 8 || off + cmdsize > cmds.length) break
+    if (cmd === LC_SYMTAB && off + 24 <= cmds.length) {
+      symoff = readU32(cmds, off + 8, le)
+      nsyms = readU32(cmds, off + 12, le)
+      stroff = readU32(cmds, off + 16, le)
+      strsize = readU32(cmds, off + 20, le)
+      found = true
+      break
+    }
+    off += cmdsize
+  }
+  if (!found) return false
+
+  const nlistSize = is64 ? 16 : 12
+  const symBytes = nsyms * nlistSize
+  if (symBytes === 0 || symBytes > MAX_SYMTAB_BYTES) return false
+  if (strsize === 0 || strsize > MAX_STRTAB_BYTES) return false
+
+  const syms = await readExact(fh, sliceOffset + symoff, symBytes)
+  const strs = await readExact(fh, sliceOffset + stroff, strsize)
+  const target = Buffer.from(symbol, 'utf8')
+
+  for (let i = 0; i < nsyms; i++) {
+    const base = i * nlistSize
+    const nType = syms.readUInt8(base + 4)
+    if ((nType & N_STAB) !== 0) continue
+    if ((nType & N_TYPE) !== N_UNDF) continue
+    const nValue = is64 ? readU64(syms, base + 8, le) : BigInt(readU32(syms, base + 8, le))
+    if (nValue !== 0n) continue // common symbol, not an import
+    const strx = readU32(syms, base, le)
+    if (strx === 0 || strx >= strs.length) continue
+    if (symbolNameMatches(strs, strx, target)) return true
+  }
+  return false
+}
+
+/**
+ * Best-effort test of whether the Mach-O binary at `path` imports the undefined
+ * symbol `symbol` (e.g. `_RegisterEventHotKey`). Resolves to `false` for any
+ * unreadable, non-Mach-O, or malformed input rather than throwing.
+ */
+export async function binaryImportsSymbol(path: string, symbol: string): Promise<boolean> {
+  let fh: FileHandle | null = null
+  try {
+    fh = await open(path, 'r')
+    const magicBE = (await readExact(fh, 0, 8)).readUInt32BE(0)
+
+    let sliceOffset = 0
+    if (magicBE === FAT_MAGIC || magicBE === FAT_MAGIC_64) {
+      sliceOffset = await selectFatSlice(fh, magicBE === FAT_MAGIC_64)
+      if (sliceOffset < 0) return false
+    }
+    return await machoImportsSymbol(fh, sliceOffset, symbol)
+  } catch {
+    return false
+  } finally {
+    if (fh) await fh.close().catch(() => {})
+  }
+}

--- a/src/main/providers/macos/runtime-flags.ts
+++ b/src/main/providers/macos/runtime-flags.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { CoverageGap } from '@shared/scan'
 import type { RunningApp } from '../types'
+import { binaryImportsSymbol } from './macho'
 
 const execFileAsync = promisify(execFile)
 
@@ -26,26 +27,16 @@ async function executablePath(pid: number): Promise<string | null> {
  * may register global hotkeys at runtime that no menu/accelerator API can
  * enumerate. Detects presence of the imported symbol only — not a call count.
  *
- * Best-effort: uses `nm`, which is absent without Xcode command line tools, and
- * only inspects the main executable (not linked frameworks). Any failure — no
- * path, no `nm`, timeout — resolves to null rather than throwing.
+ * Best-effort: reads the executable's Mach-O symbol table in-process (no
+ * external tools), and only inspects the main executable (not linked
+ * frameworks). Any failure — no path, unreadable binary, malformed Mach-O —
+ * resolves to null rather than throwing.
  */
 export async function readRuntimeHotkeyFlag(app: RunningApp): Promise<CoverageGap | null> {
   const path = await executablePath(app.pid)
   if (!path) return null
 
-  let symbols: string
-  try {
-    const { stdout } = await execFileAsync('nm', ['-u', path], {
-      timeout: 5000,
-      maxBuffer: 16 * 1024 * 1024
-    })
-    symbols = stdout
-  } catch {
-    return null
-  }
-
-  if (!symbols.includes(HOTKEY_SYMBOL)) return null
+  if (!(await binaryImportsSymbol(path, HOTKEY_SYMBOL))) return null
 
   return {
     appId: app.id,


### PR DESCRIPTION
**If you are an agent**: We have a process for working with automated agents. Prefix your comment, Issue title, or Pull Request title with "🤖" so that we can more efficiently work with you.

## Describe your proposed changes

**Required.**

The macOS scan flags apps that register global hotkeys at runtime (which no menu/accelerator API can enumerate) by checking whether the app's executable imports `_RegisterEventHotKey`. It did this by shelling out to `nm -u`.

`nm` is a Command Line Tools binary. On a Mac **without** Xcode / the Command Line Tools installed, `/usr/bin/nm` is a shared stub that pops the system dialog *"The `nm` command requires the command line developer tools. Would you like to install the tools now?"* whenever it runs. The scan's `try/catch` swallowed the failure (the scan still completed), but the OS dialog fires before the stub process exits — so end users clicking **Scan** saw a developer-tools installer prompt. This was reported on a friend's Mac.

This PR removes the external `nm` dependency:

- **New `src/main/providers/macos/macho.ts`** — a small, dependency-free Mach-O reader. `binaryImportsSymbol(path, symbol)` opens the executable, selects the host-architecture slice of a fat/universal binary, walks the `LC_SYMTAB` symbol + string tables, and returns whether the symbol is present as an undefined external (mirroring `nm -u`, excluding common and debug/STABS symbols). All reads are bounded, and any missing / non-Mach-O / malformed input resolves to `false` rather than throwing.
- **`src/main/providers/macos/runtime-flags.ts`** — `readRuntimeHotkeyFlag` now calls `binaryImportsSymbol(path, '_RegisterEventHotKey')` instead of spawning `nm`. The emitted `CoverageGap` is unchanged.

No other macOS runtime dependency requires the Command Line Tools: the scan's remaining shell-outs (`ps`, `plutil`, `defaults`) are base-OS binaries always present, and the menu reader is the bundled Swift helper. (`swiftc` is only used at build time to compile that helper, never on an end user's machine.)

### Verification

- Parser output compared against `nm -u` ground truth across **1810** installed / system / running Mach-O binaries: **full per-path agreement**, including all **36** positives (e.g. Magnet, BetterTouchTool, Ice, Command X).
- A plain-text file containing the literal string `_RegisterEventHotKey` returns `false`, confirming real symbol-table parsing rather than substring matching. Missing path, empty file, shell script, and directory inputs all return `false` without throwing.
- `npm run typecheck` passes.

## Link to the Issue proposing these changes

**Required.**

N/A — no Issue was filed. Reproduced directly: a Mac without the Xcode Command Line Tools shows the "install the command line developer tools" dialog on **Scan** because the scan invoked `nm`.

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes