### PR TITLE
🤖 Show the chord filter hint as a small visible caption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -188,12 +188,12 @@ root.innerHTML = `
     <h2 class="hide-visually">Filter by keypress</h2>
     <div class="chord-wrap">
       <input id="chord" class="chord-input" type="text" readonly placeholder="Press a shortcut to filter" aria-label="Filter by pressing a keyboard shortcut" aria-describedby="chord-hint" autocomplete="off" spellcheck="false" />
-      <div id="chord-hint" class="hide-visually" aria-hidden="true">Press Escape twice or Shift + Tab + Tab to move focus out of this input.</div>
       <span class="chord-caret" aria-hidden="true"></span>
       <button class="search-clear" id="chord-clear" type="button" hidden aria-label="Clear shortcut filter">
         <i data-lucide="x" aria-hidden="true"></i>
       </button>
     </div>
+    <div id="chord-hint" class="chord-hint" aria-hidden="true">Press Escape twice or Shift + Tab + Tab to move focus out of this input.</div>
   </div>
   <footer id="footer" data-f6 tabindex="-1">
     <h2 class="hide-visually">Scan and export</h2>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -500,6 +500,14 @@ html[data-input='keyboard'] .row-button:focus {
   display: none;
 }
 
+.chord-hint {
+  padding: 6px 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 11px;
+  text-align: center;
+}
+
 .chord-wrap {
   position: relative;
   display: flex;
@@ -517,7 +525,7 @@ html[data-input='keyboard'] .row-button:focus {
   min-height: 44px;
   appearance: none;
   border: none;
-  background: var(--transparent);
+  background: var(--chord-fill);
   color: var(--text);
   border-radius: 0;
   padding: 0;


### PR DESCRIPTION
**If you are an agent**: We have a process for working with automated agents. Prefix your comment, Issue title, or Pull Request title with "🤖" so that we can more efficiently work with you.

## Describe your proposed changes

**Required.**

Small visual refinements to the chord (keypress) filter bar.

- **Surface the chord hint.** The "Press Escape twice or Shift + Tab + Tab to move focus out of this input." hint was `hide-visually` (screen-reader only, via `aria-describedby`). It's now a visible caption below the input. It keeps its `id` (still the input's `aria-describedby` target) and `aria-hidden="true"`, so screen readers get it exactly once as the input's description rather than twice.
- **Reposition it.** `#chord-hint` moved out of the `.chord-wrap` flex row (the input is `flex: 1` and would squeeze a sibling) to its own line under the input.
- **Style it.** New `.chord-hint`: `11px` (the app's small-text size), `var(--text-dim)`, centered, `6px 12px` padding, and a `1px solid var(--border)` top border matching the line above the chord input.
- **Chord input resting fill.** The input now uses `var(--chord-fill)` as its resting background (previously only on `:hover` / when filled), in both light and dark modes, so it reads as an interactive affordance at rest.

Version bumped to `1.4.4`.

### Verification

- `npm run typecheck` passes.
- Verified live via the dev server (hot reload).

## Link to the Issue proposing these changes

**Required.**

N/A — small self-contained UI polish, no Issue filed.

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes