### PR TITLE
🤖 Chord input: double-Backspace exit, previous-focus fix, inset focus rings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-cant-i-press",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-cant-i-press",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Menu-bar app that audits reserved keyboard shortcuts across the OS and running apps.",
   "main": "./out/main/index.js",
   "author": "Eric Bailey",

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -247,6 +247,11 @@ let chordEscapePresses = 0
 // press. Reset on blur and on any key that is not Shift+Tab.
 let chordShiftTabPresses = 0
 
+// Consecutive Backspace presses while the chord field is focused. Mirrors the
+// Shift+Tab counter — releases focus to the *previous* control on the second
+// press. Reset on blur and on any key that is not Backspace.
+let chordBackspacePresses = 0
+
 // Whether the macOS Fn (Globe) key is currently held. Tracked separately because
 // Chromium exposes no `event.fnKey` flag and only inconsistently reports Fn via
 // `getModifierState('Fn')`, so its own keydown/keyup is the reliable signal.
@@ -1611,6 +1616,7 @@ function clearChordFilter(): void {
   heldKeys.clear()
   chordEscapePresses = 0
   chordShiftTabPresses = 0
+  chordBackspacePresses = 0
   chordInput.value = ''
   syncChordClear()
   renderResult()
@@ -1622,16 +1628,18 @@ chordInput.addEventListener(
     event.preventDefault()
 
     // The field captures Tab to build chords, trapping focus. Two consecutive
-    // Escapes release focus to the next control; a Shift+Tab pressed twice (the
-    // second a fresh press after the first Tab's keyup) releases focus to the
-    // previous control. The first press still commits its chord (⎋ or ⇧⇥); the
-    // exit press clears it (clearChordFilter) so the field is empty on the way
-    // out. Any other key resets both counts.
+    // Escapes release focus to the next control; a Shift+Tab or a Backspace
+    // pressed twice (the second a fresh press after the first's keyup) releases
+    // focus to the previous control. The first press still commits its chord (⎋,
+    // ⇧⇥, or ⌫); the exit press clears it (clearChordFilter) so the field is
+    // empty on the way out. Any other key resets all counts.
     const isEscape = event.key === 'Escape' || event.code === 'Escape'
     const isShiftTab = (event.key === 'Tab' || event.code === 'Tab') && event.shiftKey
+    const isBackspace = event.key === 'Backspace' || event.code === 'Backspace'
     if (!event.repeat) {
       if (isEscape) {
         chordShiftTabPresses = 0
+        chordBackspacePresses = 0
         chordEscapePresses += 1
         if (chordEscapePresses >= 2) {
           // Clear before moving focus: clearChordFilter hides #chord-clear and
@@ -1642,8 +1650,18 @@ chordInput.addEventListener(
         }
       } else if (isShiftTab) {
         chordEscapePresses = 0
+        chordBackspacePresses = 0
         chordShiftTabPresses += 1
         if (chordShiftTabPresses >= 2) {
+          clearChordFilter()
+          focusPrevFrom(chordInput)
+          return
+        }
+      } else if (isBackspace) {
+        chordEscapePresses = 0
+        chordShiftTabPresses = 0
+        chordBackspacePresses += 1
+        if (chordBackspacePresses >= 2) {
           clearChordFilter()
           focusPrevFrom(chordInput)
           return
@@ -1651,6 +1669,7 @@ chordInput.addEventListener(
       } else {
         chordEscapePresses = 0
         chordShiftTabPresses = 0
+        chordBackspacePresses = 0
       }
     }
 
@@ -1696,6 +1715,7 @@ chordInput.addEventListener('blur', () => {
   heldKeys.clear()
   chordEscapePresses = 0
   chordShiftTabPresses = 0
+  chordBackspacePresses = 0
   refreshChordField([])
 })
 

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -1585,31 +1585,24 @@ function focusableElements(): HTMLElement[] {
   const selector =
     'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
   return [...document.querySelectorAll<HTMLElement>(selector)].filter(
-    (el) => el.tabIndex !== -1 && el.getClientRects().length > 0
+    (el) => el.tabIndex !== -1 && isFocusableVisible(el)
   )
 }
 
 /**
- * Focuses `target`, and if focus does not land, retries on the next animation
- * frame and once more after a timeout. The chord exits clear the filter first,
- * which rebuilds `#content` via innerHTML in the same tick; focusing a node that
- * a synchronous re-render just re-created does not always land in the menu-bar
- * popover window (the previous-direction targets — the last result row — live
- * inside that rebuilt subtree, while the next-direction target `#export` sits
- * outside it and focuses fine). The synchronous attempt preserves behavior
- * wherever it already works, so the deferred retries only engage on the miss.
+ * Reports whether `el` can actually receive focus right now. A collapsed
+ * `<details>` hides its contents via `content-visibility`, which — unlike
+ * `display:none` — keeps layout boxes, so `getClientRects()` still reports a
+ * rect for a control the user cannot reach and `.focus()` silently no-ops.
+ * `checkVisibility()` accounts for `content-visibility`, so it rejects those
+ * collapsed-section controls while still accepting off-screen rows in a
+ * `content-visibility:auto` list (which do focus, scrolling into view). The
+ * `getClientRects` fallback covers runtimes without `checkVisibility`.
  */
-function focusReliably(target: HTMLElement | null | undefined): void {
-  if (!target) return
-  const landed = (): boolean => {
-    target.focus()
-    return document.activeElement === target
-  }
-  if (landed()) return
-  requestAnimationFrame(() => {
-    if (landed()) return
-    setTimeout(landed, 0)
-  })
+function isFocusableVisible(el: HTMLElement): boolean {
+  return typeof el.checkVisibility === 'function'
+    ? el.checkVisibility()
+    : el.getClientRects().length > 0
 }
 
 /** Moves focus to the next focusable element after `current`, wrapping to first. */
@@ -1617,7 +1610,7 @@ function focusNextFrom(current: HTMLElement): void {
   const items = focusableElements()
   const index = items.indexOf(current)
   if (index === -1) return
-  focusReliably(items[index + 1] ?? items[0])
+  ;(items[index + 1] ?? items[0])?.focus()
 }
 
 /** Moves focus to the previous focusable element before `current`, wrapping to last. */
@@ -1625,7 +1618,7 @@ function focusPrevFrom(current: HTMLElement): void {
   const items = focusableElements()
   const index = items.indexOf(current)
   if (index === -1) return
-  focusReliably(items[index - 1] ?? items[items.length - 1])
+  ;(items[index - 1] ?? items[items.length - 1])?.focus()
 }
 
 /**

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -1583,7 +1583,7 @@ function commitFromHeld(mods: Modifier[]): void {
  */
 function focusableElements(): HTMLElement[] {
   const selector =
-    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), summary, [tabindex]:not([tabindex="-1"])'
   return [...document.querySelectorAll<HTMLElement>(selector)].filter(
     (el) => el.tabIndex !== -1 && isFocusableVisible(el)
   )

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -1589,12 +1589,35 @@ function focusableElements(): HTMLElement[] {
   )
 }
 
+/**
+ * Focuses `target`, and if focus does not land, retries on the next animation
+ * frame and once more after a timeout. The chord exits clear the filter first,
+ * which rebuilds `#content` via innerHTML in the same tick; focusing a node that
+ * a synchronous re-render just re-created does not always land in the menu-bar
+ * popover window (the previous-direction targets — the last result row — live
+ * inside that rebuilt subtree, while the next-direction target `#export` sits
+ * outside it and focuses fine). The synchronous attempt preserves behavior
+ * wherever it already works, so the deferred retries only engage on the miss.
+ */
+function focusReliably(target: HTMLElement | null | undefined): void {
+  if (!target) return
+  const landed = (): boolean => {
+    target.focus()
+    return document.activeElement === target
+  }
+  if (landed()) return
+  requestAnimationFrame(() => {
+    if (landed()) return
+    setTimeout(landed, 0)
+  })
+}
+
 /** Moves focus to the next focusable element after `current`, wrapping to first. */
 function focusNextFrom(current: HTMLElement): void {
   const items = focusableElements()
   const index = items.indexOf(current)
   if (index === -1) return
-  ;(items[index + 1] ?? items[0])?.focus()
+  focusReliably(items[index + 1] ?? items[0])
 }
 
 /** Moves focus to the previous focusable element before `current`, wrapping to last. */
@@ -1602,7 +1625,7 @@ function focusPrevFrom(current: HTMLElement): void {
   const items = focusableElements()
   const index = items.indexOf(current)
   if (index === -1) return
-  ;(items[index - 1] ?? items[items.length - 1])?.focus()
+  focusReliably(items[index - 1] ?? items[items.length - 1])
 }
 
 /**

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -397,6 +397,16 @@ html[data-input='keyboard'] .row-button:focus {
   outline-offset: 7px;
 }
 
+/* Draw the chord input's ring inside its box so it reads as a filled field. */
+html[data-input='keyboard'] .chord-input:focus {
+  outline-offset: -4px;
+}
+
+/* Draw the details disclosure ring inside its box, matching the chord input. */
+html[data-input='keyboard'] summary:focus {
+  outline-offset: -4px;
+}
+
 /* F6 landmark targets are focused programmatically for landmark navigation only;
    they are tabindex="-1" (not Tab stops) and must never show a focus ring. */
 [data-f6]:focus,

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -399,12 +399,12 @@ html[data-input='keyboard'] .row-button:focus {
 
 /* Draw the chord input's ring inside its box so it reads as a filled field. */
 html[data-input='keyboard'] .chord-input:focus {
-  outline-offset: -4px;
+  outline-offset: -3px;
 }
 
 /* Draw the details disclosure ring inside its box, matching the chord input. */
 html[data-input='keyboard'] summary:focus {
-  outline-offset: -4px;
+  outline-offset: -3px;
 }
 
 /* F6 landmark targets are focused programmatically for landmark navigation only;


### PR DESCRIPTION
## Describe your proposed changes

Keyboard-focus improvements for the chord filter input, plus a patch version bump.

- **Double-Backspace (⌫⌫) exit** — pressing Backspace twice in the chord input now moves focus to the previous focusable element, mirroring the existing Shift+Tab+Tab gesture. The hint text is unchanged.
- **Fix stuck previous-focus exits** — Shift+Tab×2 and Backspace×2 previously left focus trapped in the input. Root cause: `focusableElements()` treated controls inside a collapsed `<details>` as focusable because Electron 43's Chromium hides them via `content-visibility` (which, unlike `display:none`, keeps layout boxes, so `getClientRects()` still reported a rect) even though `.focus()` no-ops on them. Now filtered with `Element.checkVisibility()`.
- **Land on the last section disclosure** — those exits skipped every `<details>` disclosure because `<summary>` was absent from the focusable selector (it is natively focusable but carries no `[tabindex]`), so focus fell back to the Expand/Collapse All button. `<summary>` is now included, so the previous-direction exits land on the last `<summary>`, matching the browser's own tab order.
- **Inset focus ring** — the keyboard focus ring on the chord input and the `<summary>` disclosures uses `outline-offset: -3px`, drawn inside each box.
- **Version** bumped `1.5.0` → `1.5.1`.

Verified on the built macOS app by injecting **trusted** key events over the Chrome DevTools Protocol (untrusted synthetic `dispatchEvent` events do not reproduce the real focus behavior): Backspace×2 and Shift+Tab×2 move focus to the last `<summary>`, and Escape×2 still moves forward to `#export`.

## Link to the Issue proposing these changes

N/A — requested directly by @ericwbailey; no separate Issue was filed.

## Checklist

- [ ] I have tested these changes in Windows
- [x] I have tested these changes in macOS
- [ ] I have created an Issue to propose these changes